### PR TITLE
fix(compiler): fix components used by multiple pages

### DIFF
--- a/fe/packages/compiler/__tests__/usingComponents.spec.js
+++ b/fe/packages/compiler/__tests__/usingComponents.spec.js
@@ -34,11 +34,22 @@ describe('child component\'s usingComponents', () => {
 			{
 				name: 'app.json',
 				content: JSON.stringify({
-					pages: ['pages/index/index'],
+					pages: [
+						'pages/index/index',
+						'pages/other/other',
+					],
 				}),
 			},
 			{
 				name: 'pages/index/index.json',
+				content: JSON.stringify({
+					usingComponents: {
+						'custom-button': '../../components/custom-button/index',
+					},
+				}),
+			},
+			{
+				name: 'pages/other/other.json',
 				content: JSON.stringify({
 					usingComponents: {
 						'custom-button': '../../components/custom-button/index',
@@ -79,13 +90,12 @@ describe('child component\'s usingComponents', () => {
 	it('should collect usingComponents from child components', () => {
 		const { configInfo } = storeInfo(mockWorkPath)
 
-		Object.keys(configInfo.componentInfo).forEach((id) => {
-			const { usingComponents } = configInfo.componentInfo[id]
+		for (const [, options] of Object.entries({ ...configInfo.pageInfo, ...configInfo.componentInfo })) {
+			const { usingComponents } = options
 
-			Object.keys(usingComponents).forEach((name) => {
-				const path = usingComponents[name]
-				expect(path).toMatch(/^\/components\//)
-			})
-		})
+			for (const [, componentPath] of Object.entries(usingComponents)) {
+				expect(componentPath).toMatch(/^\/components\//)
+			}
+		}
 	})
 })

--- a/fe/packages/compiler/src/env.js
+++ b/fe/packages/compiler/src/env.js
@@ -162,11 +162,11 @@ function storeComponentConfig(pageJsonContent, pageFilePath) {
 	// 解析当前页面的自定义组件信息
 	for (const [componentName, componentPath] of Object.entries(pageJsonContent.usingComponents)) {
 		const moduleId = getModuleId(componentPath, pageFilePath)
+		pageJsonContent.usingComponents[componentName] = moduleId
 
 		if (configInfo.componentInfo[moduleId]) {
 			continue
 		}
-		pageJsonContent.usingComponents[componentName] = moduleId
 
 		const componentFilePath = path.resolve(getWorkPath(), `./${moduleId}.json`)
 		if (!fs.existsSync(componentFilePath)) {


### PR DESCRIPTION
两个页面A、B同时使用自定义组件c，由于解析A配置时已经缓存了c，接着解析B时没有修改B的usingComponents。

问题：
- B页面的usingComponents不正确
- B页面产物中没有生成c的模块定义（获取不到c）
<img width="500" alt="image" src="https://github.com/user-attachments/assets/2377d6e4-1e49-4d21-85bd-f7dd4db677e9" />
