### PR TITLE
fix(android): vh/vw broken when WebView has no layoutParams

### DIFF
--- a/android/dimina/src/main/kotlin/com/didi/dimina/ui/view/DiminaWebView.kt
+++ b/android/dimina/src/main/kotlin/com/didi/dimina/ui/view/DiminaWebView.kt
@@ -84,6 +84,13 @@ fun DiminaWebView(
 @SuppressLint("SetJavaScriptEnabled")
 private fun createWebView(context: Context, onPageLoadFinished: () -> Unit): WebView {
     return WebView(context).apply {
+        // Ensure WebView has explicit layoutParams.
+        // Chromium determines viewport size during initial layout.
+        // Missing layoutParams may cause vh/vw and window.innerHeight to be incorrect.
+        layoutParams = android.view.ViewGroup.LayoutParams(
+            android.view.ViewGroup.LayoutParams.MATCH_PARENT,
+            android.view.ViewGroup.LayoutParams.MATCH_PARENT
+        )
         // 配置 WebView 设置
         settings.apply {
             javaScriptEnabled = true

--- a/android/dimina/src/main/kotlin/com/didi/dimina/ui/view/WebViewCacheManager.kt
+++ b/android/dimina/src/main/kotlin/com/didi/dimina/ui/view/WebViewCacheManager.kt
@@ -597,6 +597,13 @@ internal fun handleFileInterceptRequest(
 @SuppressLint("SetJavaScriptEnabled")
 private fun createWebView(context: Context, onPageLoadFinished: () -> Unit): WebView {
     return WebView(context).apply {
+        // Ensure WebView has explicit layoutParams.
+        // Chromium determines viewport size during initial layout.
+        // Missing layoutParams may cause vh/vw and window.innerHeight to be incorrect.
+        layoutParams = android.view.ViewGroup.LayoutParams(
+            android.view.ViewGroup.LayoutParams.MATCH_PARENT,
+            android.view.ViewGroup.LayoutParams.MATCH_PARENT
+        )
         // 配置 WebView 设置
         settings.apply {
             javaScriptEnabled = true


### PR DESCRIPTION
### 背景

在 Android WebView 中，Chromium 会在初始布局（initial layout）阶段计算视口（viewport）的尺寸。  
如果在创建 WebView 时未显式设置 `layoutParams`，视口高度可能会被计算为 `0`。

这会导致以下问题：

- `vh` / `vw` 单位无法生效
- `window.innerHeight` 计算结果不正确
- `body` 高度被固定为 `0px`

### 修复

确保在创建 WebView 时，始终显式设置 `MATCH_PARENT` 的 `layoutParams`。

### 修复结果

- `vh` / `vw` 单位正常工作
- `window.innerHeight` 与 WebView 实际高度一致
- 页面滚动行为恢复正常

### 相关说明

Android WebView / Chromium 视口（viewport）计算机制

修复问题 [149](https://github.com/didi/dimina/issues/149)