### PR TITLE
feat(fe): add hash router for track miniapp route

### DIFF
--- a/fe/packages/container/src/index.js
+++ b/fe/packages/container/src/index.js
@@ -1,6 +1,8 @@
+import { AppManager } from '@/core/appManager'
 import { Application } from '@/pages/application/application'
 import { AppList } from '@/pages/appList/appList'
 import { Device } from '@/pages/device/device'
+import { HashRouter } from '@/utils/hashRouter'
 import '@/styles/app.scss'
 
 window.onload = function () {
@@ -9,4 +11,15 @@ window.onload = function () {
 	const appListPage = new AppList()
 	application.initRootView(appListPage)
 	device.open(application)
+
+  // restore miniapp
+	const parsed = HashRouter.parse(window.location.hash)
+	if (parsed) {
+		AppManager.openApp({
+			appId: parsed.appId,
+			path: parsed.path,
+			scene: 1001,
+			destroy: true,
+		}, application)
+	}
 }

--- a/fe/packages/container/src/pages/miniApp/miniApp.js
+++ b/fe/packages/container/src/pages/miniApp/miniApp.js
@@ -1,6 +1,7 @@
 import { AppManager } from '@/core/appManager'
 import { Bridge } from '@/core/bridge'
 import { JSCore } from '@/core/jscore'
+import { HashRouter } from '@/utils/hashRouter'
 import { mergePageConfig, queryPath, readFile, sleep, uuid } from '@/utils/util'
 import tpl from './miniApp.html?raw'
 import './miniApp.scss'
@@ -76,6 +77,7 @@ export class MiniApp {
 
 		this.bridgeList.push(entryPageBridge)
 		entryPageBridge.start()
+		HashRouter.sync(this.appId, entryPagePath, this.appInfo.query)
 
 		// 6.隐藏 loading
 		this.hideLaunchScreen()
@@ -106,6 +108,9 @@ export class MiniApp {
 		// 首次异步创建时， bridge 不存在，会在[Service]自行调用 invokeInitLifecycle
 		currentBridge?.appShow()
 		currentBridge?.pageShow()
+		if (currentBridge) {
+			HashRouter.sync(this.appId, currentBridge.opts.pagePath, currentBridge.opts.query)
+		}
 	}
 
 	onPresentOut() {
@@ -212,6 +217,7 @@ export class MiniApp {
 
 		// 触发新页面的初始化逻辑
 		bridge.start()
+		HashRouter.sync(this.appId, pagePath, query)
 
 		// 上一个页面推出
 		preWebview.el.classList.remove('dimina-native-view--instage')
@@ -288,6 +294,7 @@ export class MiniApp {
 
 				// 启动新页面
 				bridge.start()
+				HashRouter.sync(this.appId, pagePath, query)
 
 				// 设置 z-index
 				bridge.webview.el.style.zIndex = 1
@@ -338,6 +345,7 @@ export class MiniApp {
 		}
 		curBridge.resetStatus()
 		curBridge.start()
+		HashRouter.sync(this.appId, pagePath, query)
 
 		this.webviewAnimaEnd = true
 		onSuccess?.()
@@ -377,6 +385,7 @@ export class MiniApp {
 
 		// 触发上一个页面的生命周期函数
 		preBridge?.pageShow()
+		HashRouter.sync(this.appId, preBridge.opts.pagePath, preBridge.opts.query)
 		await sleep(540)
 		this.webviewAnimaEnd = true
 
@@ -427,6 +436,7 @@ export class MiniApp {
 		const closeBtn = this.el.querySelector('.dimina-mini-app-navigation__actions-close')
 
 		closeBtn.onclick = () => {
+			HashRouter.clear()
 			AppManager.closeApp(this)
 		}
 	}

--- a/fe/packages/container/src/utils/hashRouter.js
+++ b/fe/packages/container/src/utils/hashRouter.js
@@ -1,0 +1,33 @@
+/**
+ * 管理容器 URL hash，格式：#{appId}/{pagePath}?{query}
+ * 用于调试时同步小程序页面路径，并支持刷新后恢复页面状态
+ */
+export class HashRouter {
+	static build(appId, pagePath, query) {
+		const queryStr = query && Object.keys(query).length > 0
+			? `?${Object.entries(query).map(([k, v]) => `${k}=${encodeURIComponent(v)}`).join('&')}`
+			: ''
+		return `#${appId}/${pagePath}${queryStr}`
+	}
+
+	static sync(appId, pagePath, query) {
+		history.replaceState(null, '', this.build(appId, pagePath, query))
+	}
+
+	static clear() {
+		history.replaceState(null, '', window.location.pathname + window.location.search)
+	}
+
+	static parse(hash) {
+		if (!hash || hash.length <= 1)
+			return null
+		const str = hash.slice(1)
+		const slashIdx = str.indexOf('/')
+		if (slashIdx === -1)
+			return null
+		return {
+			appId: str.slice(0, slashIdx),
+			path: str.slice(slashIdx + 1), // pagePath?query，交给 queryPath 处理
+		}
+	}
+}


### PR DESCRIPTION
用于 H5 容器调试时同步小程序页面路径，并支持刷新后恢复页面状态。