### PR TITLE
Align iOS bridge result handling with Android

### DIFF
--- a/iOS/dimina/DiminaKit/Container/Api/Base/BaseAPI.swift
+++ b/iOS/dimina/DiminaKit/Container/Api/Base/BaseAPI.swift
@@ -20,14 +20,14 @@ public class BaseAPI: DMPContainerApi {
     var canIUse: DMPBridgeMethodHandler = { param, env, callback in
         guard let schema = param.getMap().get("schema") as? String else {
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: "canIUse:fail missing parameter schema")
-            return false
+            return DMPSyncResult(false)
         }
-        
+
         let registeredMethods = DMPContainerApi.getAllRegisteredMethods()
-        
+
         let isAvailable = registeredMethods.contains(schema)
-                
-        return isAvailable
+
+        return DMPSyncResult(isAvailable)
     }
     
 }

--- a/iOS/dimina/DiminaKit/Container/Api/Base/SystemAPI.swift
+++ b/iOS/dimina/DiminaKit/Container/Api/Base/SystemAPI.swift
@@ -28,14 +28,14 @@ public class SystemAPI: DMPContainerApi {
     @BridgeMethod(GET_WINDOW_INFO)
     var getWindowInfo: DMPBridgeMethodHandler = { param, env, callback in
         let windowInfo = DMPMap(DMPUIManager.shared.getDeviceDisplayInfo())
-        return windowInfo
+        return DMPSyncResult(windowInfo.toDictionary())
     }
-    
+
     // Get system settings
     @BridgeMethod(GET_SYSTEM_SETTING)
     var getSystemSetting: DMPBridgeMethodHandler = { param, env, callback in
         let result = DMPMap()
-        
+
         // 蓝牙开关状态
         let bluetoothEnabled: Bool
         if #available(iOS 10.0, *) {
@@ -44,7 +44,7 @@ public class SystemAPI: DMPContainerApi {
             // 对于低版本 iOS，可能需要其他方式检测
             bluetoothEnabled = false
         }
-        
+
         // 地理位置开关状态
         let locationEnabled: Bool
         let locationManager = CLLocationManager()
@@ -58,7 +58,7 @@ public class SystemAPI: DMPContainerApi {
 
         // Wi-Fi 开关状态（iOS 无法直接获取）
         let wifiEnabled = false
-        
+
         // 设备方向
         let deviceOrientation: String
         let orientation = UIDevice.current.orientation
@@ -71,37 +71,37 @@ public class SystemAPI: DMPContainerApi {
             // 默认为竖屏
             deviceOrientation = "portrait"
         }
-        
+
         // 填充结果
         result["bluetoothEnabled"] = bluetoothEnabled
         result["locationEnabled"] = locationEnabled
         result["wifiEnabled"] = wifiEnabled
         result["deviceOrientation"] = deviceOrientation
-                
-        return result
+
+        return DMPSyncResult(result.toDictionary())
     }
-    
+
     // Get system information synchronously
     @BridgeMethod(GET_SYSTEM_INFO_SYNC)
     var getSystemInfoSync: DMPBridgeMethodHandler = { param, env, callback in
         let systemInfo = SystemAPI.getSystemInfo()
-        return systemInfo
+        return DMPSyncResult(systemInfo.toDictionary())
     }
-    
+
     // Get system information asynchronously
     @BridgeMethod(GET_SYSTEM_INFO_ASYNC)
     var getSystemInfoAsync: DMPBridgeMethodHandler = { param, env, callback in
         let systemInfo = SystemAPI.getSystemInfo()
         DMPContainerApi.invokeSuccess(callback: callback, param: systemInfo)
-        return nil
+        return DMPAsyncResult()
     }
-    
+
     // Get system information
     @BridgeMethod(GET_SYSTEM_INFO)
     var getSystemInfo: DMPBridgeMethodHandler = { param, env, callback in
         let systemInfo = SystemAPI.getSystemInfo()
         DMPContainerApi.invokeSuccess(callback: callback, param: systemInfo)
-        return systemInfo
+        return DMPSyncResult(systemInfo.toDictionary())
     }
 
     static func getSystemInfo() -> DMPMap {

--- a/iOS/dimina/DiminaKit/Container/Api/DMPContainerApi.swift
+++ b/iOS/dimina/DiminaKit/Container/Api/DMPContainerApi.swift
@@ -30,7 +30,7 @@ public class DMPBridgeEnv {
 public typealias DMPBridgeCallback = (_ args: DMPMap, _ cbType: DMPBridgeCallbackType) -> Void
 
 // 定义桥接方法处理程序类型
-public typealias DMPBridgeMethodHandler = (_ param: DMPBridgeParam, _ env: DMPBridgeEnv, _ callback: DMPBridgeCallback?) -> Any?
+public typealias DMPBridgeMethodHandler = (_ param: DMPBridgeParam, _ env: DMPBridgeEnv, _ callback: DMPBridgeCallback?) -> DMPAPIResult
 
 // 自定义属性
 @propertyWrapper
@@ -40,7 +40,7 @@ struct BridgeMethod {
     
     init(_ name: String) {
         self.name = name
-        self.wrappedValue = { _, _, _ in }
+        self.wrappedValue = { _, _, _ in DMPNoneResult() }
         DMPContainerApi.registerMethod(name: name)
     }
     
@@ -105,12 +105,12 @@ public class DMPContainerApi: NSObject {
         return Array(bridgeHandlerMap.keys)
     }
     
-    public func invokeBridgeMethod(name: String, data: DMPBridgeParam, env: DMPBridgeEnv, callback: DMPBridgeCallback? = nil) -> Any? {
+    public func invokeBridgeMethod(name: String, data: DMPBridgeParam, env: DMPBridgeEnv, callback: DMPBridgeCallback? = nil) -> DMPAPIResult {
         if let handler = Self.getHandler(for: name) {
             return handler(data, env, callback)
         }
         print("未找到方法: \(name)")
-        return nil
+        return DMPNoneResult()
     }
     
     // 统一的回调处理方法

--- a/iOS/dimina/DiminaKit/Container/Api/Device/ClipboardAPI.swift
+++ b/iOS/dimina/DiminaKit/Container/Api/Device/ClipboardAPI.swift
@@ -24,30 +24,30 @@ public class ClipboardAPI: DMPContainerApi {
             let errorMap = DMPMap()
             errorMap.set("errMsg", "\(ClipboardAPI.SET_CLIPBOARD_DATA):fail data is required")
             DMPContainerApi.invokeFailure(callback: callback, param: errorMap, errMsg: "data is required")
-            return
+            return DMPAsyncResult()
         }
-        
+
         // 直接设置剪贴板内容
         UIPasteboard.general.string = data
-        
+
         let result = DMPMap()
         result.set("errMsg", "\(ClipboardAPI.SET_CLIPBOARD_DATA):ok")
         DMPContainerApi.invokeSuccess(callback: callback, param: result)
-        return nil
+        return DMPAsyncResult()
     }
-    
+
     // Get clipboard data
     @BridgeMethod(GET_CLIPBOARD_DATA)
     var getClipboardData: DMPBridgeMethodHandler = { param, env, callback in
         // 直接获取剪贴板内容
         let clipboardData = UIPasteboard.general.string
-        
+
         let result = DMPMap()
         if let clipboardData = clipboardData {
             result.set("data", clipboardData)
         }
         result.set("errMsg", "\(ClipboardAPI.GET_CLIPBOARD_DATA):ok")
         DMPContainerApi.invokeSuccess(callback: callback, param: result)
-        return nil
+        return DMPAsyncResult()
     }
 }

--- a/iOS/dimina/DiminaKit/Container/Api/Device/ContactAPI.swift
+++ b/iOS/dimina/DiminaKit/Container/Api/Device/ContactAPI.swift
@@ -27,7 +27,7 @@ public class ContactAPI: DMPContainerApi {
             let result = DMPMap()
             result.set("errMsg", "\(CHOOSE_CONTACT):fail")
             DMPContainerApi.invokeFailure(callback: callback, param: result, errMsg: "无法获取导航控制器")
-            return nil
+            return DMPAsyncResult()
         }
         
         DispatchQueue.main.async {
@@ -70,9 +70,9 @@ public class ContactAPI: DMPContainerApi {
             navController.present(contactPicker, animated: true)
         }
         
-        return nil
+        return DMPAsyncResult()
     }
-    
+
     // Add phone contact
     @BridgeMethod(ADD_PHONE_CONTACT)
     var addPhoneContact: DMPBridgeMethodHandler = { param, env, callback in
@@ -94,8 +94,8 @@ public class ContactAPI: DMPContainerApi {
         } else {
             ContactAPI.createContact(param: param.getMap(), callback: callback)
         }
-        
-        return nil
+
+        return DMPAsyncResult()
     }
     
     // 辅助方法：创建联系人

--- a/iOS/dimina/DiminaKit/Container/Api/Device/KeyboardAPI.swift
+++ b/iOS/dimina/DiminaKit/Container/Api/Device/KeyboardAPI.swift
@@ -24,17 +24,18 @@ public class KeyboardAPI: DMPContainerApi {
         DispatchQueue.main.async {
             UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
         }
-        
+
         let result = DMPMap()
         result.set("errMsg", "\(KeyboardAPI.HIDE_KEYBOARD):ok")
         DMPContainerApi.invokeSuccess(callback: callback, param: result)
-        return nil
+        return DMPAsyncResult()
     }
-    
+
     // Adjust position
     @BridgeMethod(ADJUST_POSITION)
     var adjustPosition: DMPBridgeMethodHandler = { param, env, callback in
         // Empty implementation for adjusting the keyboard position
+        return DMPNoneResult()
     }
     
 }

--- a/iOS/dimina/DiminaKit/Container/Api/Device/NetworkTypeAPI.swift
+++ b/iOS/dimina/DiminaKit/Container/Api/Device/NetworkTypeAPI.swift
@@ -27,7 +27,7 @@ public class NetworkTypeAPI: DMPContainerApi {
         result.set("errMsg", "\(NetworkTypeAPI.GET_NETWORK_TYPE):ok")
         result.set("networkType", networkType)
         DMPContainerApi.invokeSuccess(callback: callback, param: result)
-        return nil
+        return DMPAsyncResult()
     }
     
     // Helper method to get network type

--- a/iOS/dimina/DiminaKit/Container/Api/Device/PhoneAPI.swift
+++ b/iOS/dimina/DiminaKit/Container/Api/Device/PhoneAPI.swift
@@ -27,15 +27,15 @@ public class PhoneAPI: DMPContainerApi {
             let result = DMPMap()
             result.set("errMsg", "\(PhoneAPI.MAKE_PHONE_CALL):fail phoneNumber is required")
             DMPContainerApi.invokeFailure(callback: callback, param: result, errMsg: "phoneNumber is required")
-            return
+            return DMPAsyncResult()
         }
-        
+
         // 构建电话 URL
         guard let url = URL(string: "tel:\(phoneNumber)") else {
             let result = DMPMap()
             result.set("errMsg", "\(PhoneAPI.MAKE_PHONE_CALL):fail invalid phone number")
             DMPContainerApi.invokeFailure(callback: callback, param: result, errMsg: "invalid phone number")
-            return
+            return DMPAsyncResult()
         }
 
         // 检查设备是否支持拨号
@@ -43,7 +43,7 @@ public class PhoneAPI: DMPContainerApi {
             let result = DMPMap()
             result.set("errMsg", "\(PhoneAPI.MAKE_PHONE_CALL):fail device does not support phone calls")
             DMPContainerApi.invokeFailure(callback: callback, param: result, errMsg: "device does not support phone calls")
-            return
+            return DMPAsyncResult()
         }
 
         // 在主线程上打开 URL
@@ -59,6 +59,6 @@ public class PhoneAPI: DMPContainerApi {
                 }
             }
         }
-        return nil
+        return DMPAsyncResult()
     }
 }

--- a/iOS/dimina/DiminaKit/Container/Api/Device/VibrateAPI.swift
+++ b/iOS/dimina/DiminaKit/Container/Api/Device/VibrateAPI.swift
@@ -29,23 +29,23 @@ public class VibrateAPI: DMPContainerApi {
         let result = DMPMap()
         result.set("errMsg", "\(VIBRATE_SHORT):ok")
         DMPContainerApi.invokeSuccess(callback: callback, param: result)
-        
-        return nil
+
+        return DMPAsyncResult()
     }
-    
+
     // Vibrate long
     @BridgeMethod(VIBRATE_LONG)
     var vibrateLong: DMPBridgeMethodHandler = { param, env, callback in
         DispatchQueue.main.async {
             AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)
         }
-        
+
         // Return success response
         let result = DMPMap()
         result.set("errMsg", "\(VIBRATE_LONG):ok")
         DMPContainerApi.invokeSuccess(callback: callback, param: result)
-        
-        return nil
+
+        return DMPAsyncResult()
     }
     
     // Helper method to get vibration pattern

--- a/iOS/dimina/DiminaKit/Container/Api/Media/ImageAPI.swift
+++ b/iOS/dimina/DiminaKit/Container/Api/Media/ImageAPI.swift
@@ -37,47 +37,47 @@ public class ImageAPI: DMPContainerApi {
     var saveImageToPhotosAlbum: DMPBridgeMethodHandler = { param, env, callback in
         guard let filePath = param.getMap()["filePath"] as? String else {
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: "filePath is required")
-            return
+            return DMPAsyncResult()
         }
-        
+
         // 检查权限配置
         guard DMPPermissionManager.shared.isPermissionConfigured(.photoLibrary) else {
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: "Photo library permission not configured in Info.plist")
-            return
+            return DMPAsyncResult()
         }
-        
+
         // 检查权限
         DMPPermissionManager.shared.requestPermission(.photoLibrary) { status in
             guard status == .authorized else {
                 DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: "Photo library permission denied")
                 return
             }
-            
+
             // 加载图片
             guard let image = UIImage(contentsOfFile: filePath) else {
                 DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: "Failed to load image")
                 return
             }
-            
+
             // 保存到相册
             UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
             DMPContainerApi.invokeSuccess(callback: callback, param: nil)
         }
-        
-        return nil
+
+        return DMPAsyncResult()
     }
-    
+
     // Preview image
     @BridgeMethod(PREVIEW_IMAGE)
     var previewImage: DMPBridgeMethodHandler = { param, env, callback in
         guard let urls = param.getMap()["urls"] as? [String] else {
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: "urls is required")
-            return
+            return DMPAsyncResult()
         }
-        
+
         if urls.isEmpty {
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: "urls cannot be empty")
-            return
+            return DMPAsyncResult()
         }
         
         let current = param.getMap()["current"] as? String ?? urls.first!
@@ -90,7 +90,7 @@ public class ImageAPI: DMPContainerApi {
                 return realUrl ?? url
             }
             let previewVC = DMPImagePreviewViewController(urls: realUrls, current: current, showMenu: showMenu)
-            
+
             if let topVC = DMPUIManager.getCurrentWindow()?.rootViewController?.topMostViewController() {
                 topVC.present(previewVC, animated: true) {
                     DMPContainerApi.invokeSuccess(callback: callback, param: nil)
@@ -99,29 +99,29 @@ public class ImageAPI: DMPContainerApi {
                 DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: "Cannot find view controller to present on")
             }
         }
-        
-        return nil
+
+        return DMPAsyncResult()
     }
-    
+
     // Compress image
     @BridgeMethod(COMPRESS_IMAGE)
     var compressImage: DMPBridgeMethodHandler = { param, env, callback in
         guard let src = param.getMap()["src"] as? String else {
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: "src is required")
-            return
+            return DMPAsyncResult()
         }
 
         let sandboxPath = DMPFileUtil.sandboxPathFromVPath(from: src, appId: env.appId)
         
         guard let sandboxPath = sandboxPath else {
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: "Failed to get sandbox path")
-            return
+            return DMPAsyncResult()
         }
 
         // 读取图片
         guard let image = UIImage(contentsOfFile: sandboxPath) else {
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: "Failed to load image")
-            return
+            return DMPAsyncResult()
         }
         
         // 压缩参数
@@ -145,18 +145,18 @@ public class ImageAPI: DMPContainerApi {
         let compressionQuality = Float(quality) / 100.0
         guard let data = resizedImage.jpegData(compressionQuality: CGFloat(compressionQuality)) else {
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: "Failed to compress image")
-            return
+            return DMPAsyncResult()
         }
 
         let fileModel: DMPImageFileModel? = DMPFileUtil.createTemporaryImagePath(data: data, appId: env.appId)
         guard let fileModel = fileModel else {
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: "Failed to create temporary image path")
-            return
+            return DMPAsyncResult()
         }
 
         DMPContainerApi.invokeSuccess(callback: callback, param: DMPMap(["tempFilePath": fileModel.vPath]))
 
-        return nil
+        return DMPAsyncResult()
     }
     
     // Choose image
@@ -210,9 +210,9 @@ public class ImageAPI: DMPContainerApi {
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: "Invalid sourceType")
         }
         
-        return nil
+        return DMPAsyncResult()
     }
-    
+
     // 检查并请求相册权限
     private static func checkAndRequestAlbumPermission(count: Int, sizeTypes: [String], env: DMPBridgeEnv, callback: DMPBridgeCallback?) {
         // 检查权限配置

--- a/iOS/dimina/DiminaKit/Container/Api/Media/VideoAPI.swift
+++ b/iOS/dimina/DiminaKit/Container/Api/Media/VideoAPI.swift
@@ -35,12 +35,12 @@ public class VideoAPI: DMPContainerApi {
         // 检查参数有效性
         if count <= 0 || count > 20 {
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: "count must be between 1 and 20")
-            return
+            return DMPAsyncResult()
         }
-        
+
         if maxDuration < 3 || maxDuration > 60 {
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: "maxDuration must be between 3 and 60 seconds")
-            return
+            return DMPAsyncResult()
         }
         
         // 如果sourceTypes包含多种选择，则显示ActionSheet让用户选择
@@ -86,10 +86,10 @@ public class VideoAPI: DMPContainerApi {
         } else {
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: "Invalid sourceType")
         }
-        
-        return nil
+
+        return DMPAsyncResult()
     }
-    
+
     // Choose video
     @BridgeMethod(CHOOSE_VIDEO)
     var chooseVideo: DMPBridgeMethodHandler = { param, env, callback in
@@ -142,10 +142,10 @@ public class VideoAPI: DMPContainerApi {
         } else {
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: "Invalid sourceType")
         }
-        
-        return nil
+
+        return DMPAsyncResult()
     }
-    
+
     // MARK: - Helper methods for chooseMedia
     
     // 检查并请求相册权限 (用于 chooseMedia)

--- a/iOS/dimina/DiminaKit/Container/Api/Network/NetworkAPI.swift
+++ b/iOS/dimina/DiminaKit/Container/Api/Network/NetworkAPI.swift
@@ -40,7 +40,7 @@ public class NetworkAPI: DMPContainerApi {
         // 验证URL
         guard let _ = URL(string: url) else {
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: "request:fail invalid url")
-            return
+            return DMPAsyncResult()
         }
         
         // 转换header
@@ -120,9 +120,9 @@ public class NetworkAPI: DMPContainerApi {
             }
         )
         
-        return nil
+        return DMPAsyncResult()
     }
-    
+
     /**
      * Bridge method for file download
      * Mimics wx.downloadFile API from WeChat Mini Program
@@ -140,7 +140,7 @@ public class NetworkAPI: DMPContainerApi {
         // 验证URL
         guard let _ = URL(string: url) else {
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: "downloadFile:fail invalid url")
-            return
+            return DMPAsyncResult()
         }
         
         // 转换header
@@ -186,9 +186,9 @@ public class NetworkAPI: DMPContainerApi {
             }
         )
         
-        return nil
+        return DMPAsyncResult()
     }
-    
+
     /**
      * Bridge method for file upload
      * Mimics wx.uploadFile API from WeChat Mini Program
@@ -209,19 +209,19 @@ public class NetworkAPI: DMPContainerApi {
         if url.isEmpty || filePath.isEmpty || name.isEmpty {
             let errMsg = "uploadFile:fail missing required parameters"
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: errMsg)
-            return
+            return DMPAsyncResult()
         }
-        
+
         // 验证URL
         guard let _ = URL(string: url) else {
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: "uploadFile:fail invalid url")
-            return
+            return DMPAsyncResult()
         }
-        
+
         // 验证文件路径
         if !FileManager.default.fileExists(atPath: filePath) {
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: "uploadFile:fail file does not exist")
-            return
+            return DMPAsyncResult()
         }
         
         // 转换header
@@ -275,6 +275,6 @@ public class NetworkAPI: DMPContainerApi {
             }
         )
         
-        return nil
+        return DMPAsyncResult()
     }
 }

--- a/iOS/dimina/DiminaKit/Container/Api/Route/RouteAPI.swift
+++ b/iOS/dimina/DiminaKit/Container/Api/Route/RouteAPI.swift
@@ -33,7 +33,7 @@ public class RouteAPI: DMPContainerApi {
             let errorMap = DMPMap()
             errorMap.set("errMsg", "\(RouteAPI.NAVIGATE_TO):fail URL cannot be empty")
             DMPContainerApi.invokeFailure(callback: callback, param: errorMap, errMsg: "URL cannot be empty")
-            return
+            return DMPAsyncResult()
         }
 
         let app = DMPAppManager.sharedInstance().getApp(appIndex: env.appIndex)
@@ -49,7 +49,7 @@ public class RouteAPI: DMPContainerApi {
         let result = DMPMap()
         result.set("errMsg", "\(RouteAPI.NAVIGATE_TO):ok")
         DMPContainerApi.invokeSuccess(callback: callback, param: result)
-        return nil
+        return DMPAsyncResult()
     }
 
     // Replace current page with a new one
@@ -61,7 +61,7 @@ public class RouteAPI: DMPContainerApi {
             let errorMap = DMPMap()
             errorMap.set("errMsg", "\(RouteAPI.REDIRECT_TO):fail URL cannot be empty")
             DMPContainerApi.invokeFailure(callback: callback, param: errorMap, errMsg: "URL cannot be empty")
-            return
+            return DMPAsyncResult()
         }
 
         let app = DMPAppManager.sharedInstance().getApp(appIndex: env.appIndex)
@@ -77,7 +77,7 @@ public class RouteAPI: DMPContainerApi {
         let result = DMPMap()
         result.set("errMsg", "\(RouteAPI.REDIRECT_TO):ok")
         DMPContainerApi.invokeSuccess(callback: callback, param: result)
-        return nil
+        return DMPAsyncResult()
     }
 
     // Navigate back to the previous page
@@ -86,16 +86,16 @@ public class RouteAPI: DMPContainerApi {
         let param = param.getMap()
         // 获取当前应用
         let app = DMPAppManager.sharedInstance().getApp(appIndex: env.appIndex)
-        
+
         Task { @MainActor in
             app?.getNavigator()?.navigateBack(delta: param.getInt(key: "delta") ?? 1)
         }
-        
+
         // 返回成功响应
         let result = DMPMap()
         result.set("errMsg", "\(RouteAPI.NAVIGATE_BACK):ok")
         DMPContainerApi.invokeSuccess(callback: callback, param: result)
-        return nil
+        return DMPAsyncResult()
     }
 
     // Close all pages and open a specific page
@@ -107,7 +107,7 @@ public class RouteAPI: DMPContainerApi {
             let errorMap = DMPMap()
             errorMap.set("errMsg", "\(RouteAPI.RE_LAUNCH):fail URL cannot be empty")
             DMPContainerApi.invokeFailure(callback: callback, param: errorMap, errMsg: "URL cannot be empty")
-            return
+            return DMPAsyncResult()
         }
 
         let app = DMPAppManager.sharedInstance().getApp(appIndex: env.appIndex)
@@ -123,6 +123,6 @@ public class RouteAPI: DMPContainerApi {
         let result = DMPMap()
         result.set("errMsg", "\(RouteAPI.RE_LAUNCH):ok")
         DMPContainerApi.invokeSuccess(callback: callback, param: result)
-        return nil
+        return DMPAsyncResult()
     }
 }

--- a/iOS/dimina/DiminaKit/Container/Api/Storage/StorageAPI.swift
+++ b/iOS/dimina/DiminaKit/Container/Api/Storage/StorageAPI.swift
@@ -36,43 +36,43 @@ public class StorageAPI: DMPContainerApi {
     @BridgeMethod(SET_STORAGE_SYNC)
     var setStorageSync: DMPBridgeMethodHandler = { param, env, callback in
         let param = param.getMap()
-        guard let key = param.get("key") as? String else { return false }
+        guard let key = param.get("key") as? String else { return DMPSyncResult(false) }
         let data = param.get("data")
         let encrypt = param.get("encrypt") as? Bool ?? false
-        
-        guard let data = data else { return false }
-        
+
+        guard let data = data else { return DMPSyncResult(false) }
+
         let result = DMPStorage.shared.set(key: key, value: data, encrypted: encrypt)
-        return result
+        return DMPSyncResult(result)
     }
-    
+
     // Get storage synchronously
     @BridgeMethod(GET_STORAGE_SYNC)
     var getStorageSync: DMPBridgeMethodHandler = { param, env, callback in
-        guard let key = param.getValue() as? String else { return }
+        guard let key = param.getValue() as? String else { return DMPNoneResult() }
         let value = DMPStorage.shared.get(key: key, encrypted: false)
-        return DMPBridgeParam(value: value)
+        return DMPSyncResult(value)
     }
-    
+
     // Remove storage synchronously
     @BridgeMethod(REMOVE_STORAGE_SYNC)
     var removeStorageSync: DMPBridgeMethodHandler = { param, env, callback in
         let param = param.getMap()
-        guard let key = param.get("key") as? String else { return false }
+        guard let key = param.get("key") as? String else { return DMPSyncResult(false) }
         let encrypt = param.get("encrypt") as? Bool ?? false
-        
+
         DMPStorage.shared.remove(key: key, encrypted: encrypt)
-        return true
+        return DMPSyncResult(true)
     }
-    
+
     // Clear storage synchronously
     @BridgeMethod(CLEAR_STORAGE_SYNC)
     var clearStorageSync: DMPBridgeMethodHandler = { param, env, callback in
         // 清除所有存储（包括加密和非加密）
         DMPStorage.shared.clearAllStorage()
-        return true
+        return DMPSyncResult(true)
     }
-    
+
     // Set storage
     @BridgeMethod(SET_STORAGE)
     var setStorage: DMPBridgeMethodHandler = { param, env, callback in
@@ -80,22 +80,22 @@ public class StorageAPI: DMPContainerApi {
         guard let key = param.get("key") as? String else {
             let errMsg = "\(SET_STORAGE):fail missing parameter key"
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: errMsg)
-            return nil
+            return DMPAsyncResult()
         }
-        
+
         let data = param.get("data")
         let encrypt = param.get("encrypt") as? Bool ?? false
-        
+
         guard let data = data else {
             let errMsg = "\(SET_STORAGE):fail missing parameter data"
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: errMsg)
-            return nil
+            return DMPAsyncResult()
         }
-        
+
         // 在后台线程执行存储操作
         DispatchQueue.global().async {
             let success = DMPStorage.shared.set(key: key, value: data, encrypted: encrypt)
-            
+
             DispatchQueue.main.async {
                 if success {
                     let resultMap = DMPMap()
@@ -106,10 +106,10 @@ public class StorageAPI: DMPContainerApi {
                 }
             }
         }
-        
-        return nil
+
+        return DMPAsyncResult()
     }
-    
+
     // Get storage
     @BridgeMethod(GET_STORAGE)
     var getStorage: DMPBridgeMethodHandler = { param, env, callback in
@@ -117,15 +117,15 @@ public class StorageAPI: DMPContainerApi {
         guard let key = param.get("key") as? String else {
             let errMsg = "\(GET_STORAGE):fail missing parameter key"
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: errMsg)
-            return nil
+            return DMPAsyncResult()
         }
-        
+
         let encrypt = param.get("encrypt") as? Bool ?? false
-        
+
         // 在后台线程执行获取操作
         DispatchQueue.global().async {
             let value = DMPStorage.shared.get(key: key, encrypted: encrypt)
-            
+
             DispatchQueue.main.async {
                 if let value = value {
                     let resultMap = DMPMap()
@@ -137,10 +137,10 @@ public class StorageAPI: DMPContainerApi {
                 }
             }
         }
-        
-        return nil
+
+        return DMPAsyncResult()
     }
-    
+
     // Remove storage
     @BridgeMethod(REMOVE_STORAGE)
     var removeStorage: DMPBridgeMethodHandler = { param, env, callback in
@@ -148,73 +148,73 @@ public class StorageAPI: DMPContainerApi {
         guard let key = param.get("key") as? String else {
             let errMsg = "\(REMOVE_STORAGE):fail missing parameter key"
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: errMsg)
-            return nil
+            return DMPAsyncResult()
         }
-        
+
         let encrypt = param.get("encrypt") as? Bool ?? false
-        
+
         // 在后台线程执行删除操作
         DispatchQueue.global().async {
             DMPStorage.shared.remove(key: key, encrypted: encrypt)
-            
+
             DispatchQueue.main.async {
                 let resultMap = DMPMap()
                 resultMap.set("errMsg", "\(REMOVE_STORAGE):ok")
                 DMPContainerApi.invokeSuccess(callback: callback, param: resultMap)
             }
         }
-        
-        return nil
+
+        return DMPAsyncResult()
     }
-    
+
     // Clear storage
     @BridgeMethod(CLEAR_STORAGE)
     var clearStorage: DMPBridgeMethodHandler = { param, env, callback in
         // 在后台线程执行清除操作
         DispatchQueue.global().async {
             DMPStorage.shared.clearAllStorage()
-            
+
             DispatchQueue.main.async {
                 let resultMap = DMPMap()
                 resultMap.set("errMsg", "\(CLEAR_STORAGE):ok")
                 DMPContainerApi.invokeSuccess(callback: callback, param: resultMap)
             }
         }
-        
-        return nil
+
+        return DMPAsyncResult()
     }
-    
+
     // Get storage info synchronously
     @BridgeMethod(GET_STORAGE_INFO_SYNC)
     var getStorageInfoSync: DMPBridgeMethodHandler = { param, env, callback in
         let storageInfo = DMPStorage.shared.getAllStorageInfo()
-        
+
         let result = DMPMap()
         result.set("keys", storageInfo.keys)
         result.set("currentSize", storageInfo.currentSize)
         result.set("limitSize", storageInfo.limitSize)
-        
-        return result
+
+        return DMPSyncResult(result.toDictionary())
     }
-    
+
     // Get storage info
     @BridgeMethod(GET_STORAGE_INFO)
     var getStorageInfo: DMPBridgeMethodHandler = { param, env, callback in
         // 在后台线程执行获取存储信息操作
         DispatchQueue.global().async {
             let storageInfo = DMPStorage.shared.getAllStorageInfo()
-            
+
             DispatchQueue.main.async {
                 let resultMap = DMPMap()
                 resultMap.set("keys", storageInfo.keys)
                 resultMap.set("currentSize", storageInfo.currentSize)
                 resultMap.set("limitSize", storageInfo.limitSize)
                 resultMap.set("errMsg", "\(GET_STORAGE_INFO):ok")
-                
+
                 DMPContainerApi.invokeSuccess(callback: callback, param: resultMap)
             }
         }
-        
-        return nil
+
+        return DMPAsyncResult()
     }
 }

--- a/iOS/dimina/DiminaKit/Container/Api/UI/InteractionAPI.swift
+++ b/iOS/dimina/DiminaKit/Container/Api/UI/InteractionAPI.swift
@@ -30,7 +30,7 @@ public class InteractionAPI: DMPContainerApi {
             let errorMap = DMPMap()
             errorMap.set("errMsg", "\(InteractionAPI.SHOW_TOAST):fail title is required")
             DMPContainerApi.invokeFailure(callback: callback, param: errorMap, errMsg: "title is required")
-            return
+            return DMPAsyncResult()
         }
         
         // 获取可选参数
@@ -63,7 +63,7 @@ public class InteractionAPI: DMPContainerApi {
         let result = DMPMap()
         result.set("errMsg", "\(InteractionAPI.SHOW_TOAST):ok")
         DMPContainerApi.invokeSuccess(callback: callback, param: result)
-        return nil
+        return DMPAsyncResult()
     }
     
     // Show modal
@@ -99,7 +99,7 @@ public class InteractionAPI: DMPContainerApi {
                 DMPContainerApi.invokeSuccess(callback: callback, param: result)
             }
         }
-        return nil
+        return DMPAsyncResult()
     }
     
     // Show loading
@@ -111,7 +111,7 @@ public class InteractionAPI: DMPContainerApi {
             let errorMap = DMPMap()
             errorMap.set("errMsg", "\(InteractionAPI.SHOW_LOADING):fail title is required")
             DMPContainerApi.invokeFailure(callback: callback, param: errorMap, errMsg: "title is required")
-            return
+            return DMPAsyncResult()
         }
         
         // 获取可选参数
@@ -127,7 +127,7 @@ public class InteractionAPI: DMPContainerApi {
         let result = DMPMap()
         result.set("errMsg", "\(InteractionAPI.SHOW_LOADING):ok")
         DMPContainerApi.invokeSuccess(callback: callback, param: result)
-        return nil
+        return DMPAsyncResult()
     }
     
     // Hide toast
@@ -142,7 +142,7 @@ public class InteractionAPI: DMPContainerApi {
         let result = DMPMap()
         result.set("errMsg", "\(InteractionAPI.HIDE_TOAST):ok")
         DMPContainerApi.invokeSuccess(callback: callback, param: result)
-        return nil
+        return DMPAsyncResult()
     }
     
     // Hide loading
@@ -158,7 +158,7 @@ public class InteractionAPI: DMPContainerApi {
         let result = DMPMap()
         result.set("errMsg", "\(InteractionAPI.HIDE_LOADING):ok")
         DMPContainerApi.invokeSuccess(callback: callback, param: result)
-        return nil
+        return DMPAsyncResult()
     }
     
     // Show action sheet
@@ -186,7 +186,7 @@ public class InteractionAPI: DMPContainerApi {
             let errorMap = DMPMap()
             errorMap.set("errMsg", "\(InteractionAPI.SHOW_ACTION_SHEET):fail itemList is empty")
             DMPContainerApi.invokeFailure(callback: callback, param: errorMap, errMsg: "itemList is empty")
-            return
+            return DMPAsyncResult()
         }
         
         // 在主线程上显示操作表
@@ -203,7 +203,7 @@ public class InteractionAPI: DMPContainerApi {
                 DMPContainerApi.invokeSuccess(callback: callback, param: result)
             }
         }
-        return nil
+        return DMPAsyncResult()
     }
     
 }

--- a/iOS/dimina/DiminaKit/Container/Api/UI/MenuAPI.swift
+++ b/iOS/dimina/DiminaKit/Container/Api/UI/MenuAPI.swift
@@ -20,7 +20,7 @@ public class MenuAPI: DMPContainerApi {
     @BridgeMethod(GET_MENU_BUTTON_BOUNDING_CLIENT_RECT)
     var getMenuButtonBoundingClientRect: DMPBridgeMethodHandler = { param, env, callback in
         let menuButtonInfo = MenuAPI.getMenuButtonBoundingClientRect()
-        return menuButtonInfo
+        return DMPSyncResult(menuButtonInfo.toDictionary())
     }
     
     static func getMenuButtonBoundingClientRect() -> DMPMap {

--- a/iOS/dimina/DiminaKit/Container/Api/UI/NavigationBarAPI.swift
+++ b/iOS/dimina/DiminaKit/Container/Api/UI/NavigationBarAPI.swift
@@ -24,7 +24,7 @@ public class NavigationBarAPI: DMPContainerApi {
         guard let title = param.get("title") as? String else {
             let errorMsg = "\(SET_NAVIGATION_BAR_TITLE):fail missing parameter title"
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: errorMsg)
-            return nil
+            return DMPAsyncResult()
         }
         
         
@@ -33,7 +33,7 @@ public class NavigationBarAPI: DMPContainerApi {
         guard let navigationController = app?.getNavigator()?.navigationController else {
             let errorMsg = "\(SET_NAVIGATION_BAR_TITLE):fail navigation controller not found"
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: errorMsg)
-            return nil
+            return DMPAsyncResult()
         }
         
         DispatchQueue.main.async {
@@ -44,7 +44,7 @@ public class NavigationBarAPI: DMPContainerApi {
             DMPContainerApi.invokeSuccess(callback: callback, param: result)
         }
         
-        return nil
+        return DMPAsyncResult()
     }
     
     // Set navigation bar color
@@ -55,13 +55,13 @@ public class NavigationBarAPI: DMPContainerApi {
               let backgroundColor = param.get("backgroundColor") as? String else {
             let errorMsg = "\(SET_NAVIGATION_BAR_COLOR):fail missing required parameters"
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: errorMsg)
-            return nil
+            return DMPAsyncResult()
         }
         
         guard frontColor == "#ffffff" || frontColor == "#000000" else {
             let errorMsg = "\(SET_NAVIGATION_BAR_COLOR):fail frontColor only supports #ffffff or #000000"
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: errorMsg)
-            return nil
+            return DMPAsyncResult()
         }
         
         let animation = param.getDMPMap(key: "animation")
@@ -133,6 +133,6 @@ public class NavigationBarAPI: DMPContainerApi {
             DMPContainerApi.invokeSuccess(callback: callback, param: result)
         }
         
-        return nil
+        return DMPAsyncResult()
     }
 }

--- a/iOS/dimina/DiminaKit/Container/Api/UI/ScrollAPI.swift
+++ b/iOS/dimina/DiminaKit/Container/Api/UI/ScrollAPI.swift
@@ -25,13 +25,13 @@ public class ScrollAPI: DMPContainerApi {
         
         guard let app = DMPAppManager.sharedInstance().getApp(appIndex: env.appIndex) else {
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: "invalid app")
-            return
+            return DMPAsyncResult()
         }
-        
+
         guard let render = app.render,
               let webview = render.getWebView(byId: env.webViewId) else {
             DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: "invalid render or webview")
-            return
+            return DMPAsyncResult()
         }
         
         let wkWebView = webview.getWebView()
@@ -44,6 +44,6 @@ public class ScrollAPI: DMPContainerApi {
             }
         }
         
-        return nil
+        return DMPAsyncResult()
     }
 }

--- a/iOS/dimina/DiminaKit/Container/DMPContainer.swift
+++ b/iOS/dimina/DiminaKit/Container/DMPContainer.swift
@@ -186,6 +186,7 @@ public class DMPContainer {
 
         print("Bridge invoke error: 未找到方法: \(methodName)")
         return DMPSyncResult(["error": "未找到方法: \(methodName)"])
+    }
 
     /// 处理 extOnBridge：启动持续订阅，保存取消函数
     private func handleExtOnBridge(

--- a/iOS/dimina/DiminaKit/Container/DMPContainer.swift
+++ b/iOS/dimina/DiminaKit/Container/DMPContainer.swift
@@ -104,7 +104,7 @@ public class DMPContainer {
 
     public func callBridgeMethod(
         methodName: String, webViewId: Int, param: DMPBridgeParam, app: DMPApp
-    ) -> Any {
+    ) -> DMPAPIResult {
         let moduleName = "DMPContainerBridgesModule"
         print("Bridge call: module=\(moduleName), method=\(methodName)")
         var callback: DMPBridgeCallback = { _, _ in }
@@ -151,7 +151,7 @@ public class DMPContainer {
 
         // 1. 精确命中已注册的标准 API
         if let handler = DMPContainerApi.getHandler(for: methodName) {
-            return handler(param, env, callback) ?? DMPMap()
+            return handler(param, env, callback)
         }
 
         // 2. extBridge：param 携带 "module" 字段
@@ -164,7 +164,7 @@ public class DMPContainer {
                 callback: callback,
                 extModules: extModules
             )
-            return DMPMap()
+            return DMPNoneResult()
         }
 
         // 3. extOnBridge / extOffBridge：methodName 格式为 "${module}_${event}"
@@ -181,12 +181,11 @@ public class DMPContainer {
             } else {
                 handleExtOffBridge(eventKey: methodName)
             }
-            return DMPMap()
+            return DMPNoneResult()
         }
 
         print("Bridge invoke error: 未找到方法: \(methodName)")
-        return ["error": "未找到方法: \(methodName)"]
-    }
+        return DMPSyncResult(["error": "未找到方法: \(methodName)"])
 
     /// 处理 extOnBridge：启动持续订阅，保存取消函数
     private func handleExtOnBridge(

--- a/iOS/dimina/DiminaKit/Render/DMPWebViewInvoke.swift
+++ b/iOS/dimina/DiminaKit/Render/DMPWebViewInvoke.swift
@@ -52,30 +52,33 @@ public class DMPWebViewInvoke {
                     
                     // 处理消息并获取返回值
                     let result = self.processInvokeMessage(type: type, body: body, target: target)
-                    
+
                     // 将结果返回给JS
                     if let callbackId = callbackId {
                         var resultJson = "null"
-                        
+
                         // 根据返回值类型生成适当的JS表示
-                        if let resultStr = result as? String {
-                            // 字符串类型，需要加引号
-                            resultJson = "\"\(resultStr)\""
-                        } else if let resultNum = result as? NSNumber {
-                            // 数字或布尔值
-                            if CFGetTypeID(resultNum) == CFBooleanGetTypeID() {
-                                // 布尔值
-                                resultJson = resultNum.boolValue ? "true" : "false"
-                            } else {
-                                // 数字
-                                resultJson = resultNum.stringValue
+                        if let syncResult = result as? DMPSyncResult, let value = syncResult.value {
+                            // DMPAPIResult sync result - convert value to JSON
+                            if let resultStr = value as? String,
+                               let strData = try? JSONSerialization.data(withJSONObject: [resultStr]),
+                               let escaped = String(data: strData, encoding: .utf8) {
+                                // JSON-encode via array wrapper to escape quotes/backslashes/newlines
+                                resultJson = String(escaped.dropFirst().dropLast())
+                            } else if let resultNum = value as? NSNumber {
+                                if CFGetTypeID(resultNum) == CFBooleanGetTypeID() {
+                                    resultJson = resultNum.boolValue ? "true" : "false"
+                                } else {
+                                    resultJson = resultNum.stringValue
+                                }
+                            } else if let resultDict = value as? [String: Any] {
+                                resultJson = DMPUtil.jsonEncode(from: resultDict) ?? "null"
+                            } else if let resultArray = value as? [Any] {
+                                resultJson = DMPUtil.jsonEncode(from: resultArray) ?? "null"
                             }
                         } else if let resultDict = result as? [String: Any] {
-                            // 对象
+                            // Legacy dict result from non-bridge paths
                             resultJson = DMPUtil.jsonEncode(from: resultDict) ?? "null"
-                        } else if let resultArray = result as? [Any] {
-                            // 数组
-                            resultJson = DMPUtil.jsonEncode(from: resultArray) ?? "null"
                         }
                         
                         let callbackScript = """

--- a/iOS/dimina/DiminaKit/Service/DMPBridgeParam.swift
+++ b/iOS/dimina/DiminaKit/Service/DMPBridgeParam.swift
@@ -27,17 +27,17 @@ public class DMPBridgeParam {
     var isAsync: Bool = false
     
     init(value: Any) {
-        if value is [String: Any] {
+        if let dict = value as? [String: Any] {
             self.type = .object
-            self.isAsync = true
+            self.isAsync = DMPBridgeParam.hasCallbackIdentifiers(dict)
         } else if value is [Any] {
             self.type = .array
+        } else if value is Bool {
+            self.type = .boolean
         } else if value is String {
             self.type = .string
         } else if value is NSNumber {
             self.type = .number
-        } else if value is Bool {
-            self.type = .boolean
         } else if value is Float {
             self.type = .float
         } else if value is Double {
@@ -47,6 +47,34 @@ public class DMPBridgeParam {
         }
 
         self.value = value
+    }
+
+    private static func hasCallbackIdentifiers(_ dict: [String: Any]) -> Bool {
+        let callbackKeys = ["success", "fail", "complete"]
+        return callbackKeys.contains { key in
+            guard let value = dict[key] else { return false }
+            return value is String
+        }
+    }
+
+    static func from(rawValue: Any?) -> DMPBridgeParam {
+        guard let rawValue else {
+            let param = DMPBridgeParam(value: NSNull())
+            param.type = .null
+            return param
+        }
+
+        if rawValue is NSNull {
+            let param = DMPBridgeParam(value: rawValue)
+            param.type = .null
+            return param
+        }
+
+        if let param = rawValue as? DMPBridgeParam {
+            return param
+        }
+
+        return DMPBridgeParam(value: rawValue)
     }
 
     func getMap() -> DMPMap {

--- a/iOS/dimina/DiminaKit/Service/DMPEngineInvoke.swift
+++ b/iOS/dimina/DiminaKit/Service/DMPEngineInvoke.swift
@@ -28,12 +28,6 @@ public class DMPEngineInvoke {
 
             if let syncResult = result as? DMPSyncResult {
                 return DMPBridgeParam.from(rawValue: syncResult.value).getJSValue(context: context)
-            } else if result is DMPAsyncResult || result is DMPNoneResult {
-                return JSValue(nullIn: context)
-            } else if let validResult = result as? DMPMap {
-                return JSValue(object: validResult.toDictionary(), in: context)
-            } else if let param = result as? DMPBridgeParam {
-                return param.getJSValue(context: context)
             } else {
                 return JSValue(nullIn: context)
             }

--- a/iOS/dimina/DiminaKit/Service/DMPEngineInvoke.swift
+++ b/iOS/dimina/DiminaKit/Service/DMPEngineInvoke.swift
@@ -26,7 +26,11 @@ public class DMPEngineInvoke {
             let app = appResolver?()
             let result = DMPChannelProxy.messageHandler(type: type, body: body, target: target, app: app!)
 
-            if let validResult = result as? DMPMap {
+            if let syncResult = result as? DMPSyncResult {
+                return DMPBridgeParam.from(rawValue: syncResult.value).getJSValue(context: context)
+            } else if result is DMPAsyncResult || result is DMPNoneResult {
+                return JSValue(nullIn: context)
+            } else if let validResult = result as? DMPMap {
                 return JSValue(object: validResult.toDictionary(), in: context)
             } else if let param = result as? DMPBridgeParam {
                 return param.getJSValue(context: context)

--- a/iOS/dimina/DiminaKit/Service/DMPSyncResult.swift
+++ b/iOS/dimina/DiminaKit/Service/DMPSyncResult.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public class DMPAPIResult: NSObject {}
+
+/// Explicit sync result, aligned with Android's SyncResult semantics.
+/// The wrapped value is converted to a JSValue and returned to JS directly.
+public class DMPSyncResult: DMPAPIResult {
+    public let value: Any?
+
+    public init(_ value: Any?) {
+        self.value = value
+    }
+}
+
+/// Explicit async result marker, aligned with Android's AsyncResult semantics.
+/// The actual payload should be delivered through success/fail/complete callbacks.
+public class DMPAsyncResult: DMPAPIResult {
+    public let value: DMPMap?
+
+    public init(_ value: DMPMap? = nil) {
+        self.value = value
+    }
+}
+
+/// Explicit no-result marker, aligned with Android's NoneResult semantics.
+public class DMPNoneResult: DMPAPIResult {}


### PR DESCRIPTION
对齐 iOS 侧 bridge 调用在同步/异步返回语义上的处理方式，使其更接近 Android 当前的实现，并修复 createInnerAudioContext 这类需要同步返回对象的 custom API 在 iOS 上无法正常返回的问题。