### PR TITLE
fix(storage): align sync storage APIs with WeChat behavior

### DIFF
--- a/android/dimina/src/main/kotlin/com/didi/dimina/api/storage/StorageApi.kt
+++ b/android/dimina/src/main/kotlin/com/didi/dimina/api/storage/StorageApi.kt
@@ -69,7 +69,9 @@ class StorageApi : BaseApiHandler() {
                     is Double -> SyncResult(JSValue.createNumber(value))
                     is Float -> SyncResult(JSValue.createNumber(value.toDouble()))
                     is Boolean -> SyncResult(JSValue.createBoolean(value))
-                    else -> SyncResult(JSValue.createNull())
+                    is JSONArray -> SyncResult(JSValue.createObject(value.toString()))
+                    is JSONObject -> SyncResult(JSValue.createObject(value.toString()))
+                    else -> SyncResult(JSValue.createString(""))
                 }
             }
 
@@ -192,6 +194,11 @@ class StorageApi : BaseApiHandler() {
                     storage.encode(typeKey, "Array")
                 }
 
+                is JSONObject -> {
+                    storage.encode(key, data.toString())
+                    storage.encode(typeKey, "Object")
+                }
+
                 is Any -> try {
                     // For JSON-serializable objects
                     storage.encode(key, data.toString())
@@ -220,6 +227,11 @@ class StorageApi : BaseApiHandler() {
                 "Double" -> storage.decodeDouble(key, 0.0)
                 "Array" -> try {
                     JSONArray(storage.decodeString(key))
+                } catch (_: Exception) {
+                    storage.decodeString(key) // Fallback to String if parsing fails
+                }
+                "Object" -> try {
+                    JSONObject(storage.decodeString(key))
                 } catch (_: Exception) {
                     storage.decodeString(key) // Fallback to String if parsing fails
                 }

--- a/iOS/dimina/DiminaKit/Container/Api/Storage/StorageAPI.swift
+++ b/iOS/dimina/DiminaKit/Container/Api/Storage/StorageAPI.swift
@@ -32,33 +32,26 @@ public class StorageAPI: DMPContainerApi {
         DMPStorage.shared.initialize()
     }
     
-    // Set storage synchronously
+    // wx.setStorageSync(key, data) → params: [key, data]
     @BridgeMethod(SET_STORAGE_SYNC)
     var setStorageSync: DMPBridgeMethodHandler = { param, env, callback in
-        let param = param.getMap()
-        guard let key = param.get("key") as? String else { return DMPSyncResult(false) }
-        let data = param.get("data")
-        let encrypt = param.get("encrypt") as? Bool ?? false
-
-        guard let data = data else { return DMPSyncResult(false) }
-
-        let result = DMPStorage.shared.set(key: key, value: data, encrypted: encrypt)
-        return DMPSyncResult(result)
+        guard let array = param.getValue() as? [Any], array.count >= 2,
+              let key = array[0] as? String else { return DMPSyncResult(false) }
+        return DMPSyncResult(DMPStorage.shared.set(key: key, value: array[1], encrypted: false))
     }
 
-    // Get storage synchronously
+    // wx.getStorageSync(key) → params: key string
     @BridgeMethod(GET_STORAGE_SYNC)
     var getStorageSync: DMPBridgeMethodHandler = { param, env, callback in
         guard let key = param.getValue() as? String else { return DMPNoneResult() }
         let value = DMPStorage.shared.get(key: key, encrypted: false)
-        return DMPSyncResult(value)
+        return DMPSyncResult(value ?? "")
     }
 
-    // Remove storage synchronously
+    // wx.removeStorageSync(key) → params: key string
     @BridgeMethod(REMOVE_STORAGE_SYNC)
     var removeStorageSync: DMPBridgeMethodHandler = { param, env, callback in
         guard let key = param.getValue() as? String else { return DMPSyncResult(false) }
-
         DMPStorage.shared.remove(key: key, encrypted: false)
         return DMPSyncResult(true)
     }


### PR DESCRIPTION
修复 iOS 和 Android 端 Storage 同步接口的参数解析逻辑。对齐微信官方的文档

Fixes #164