### PR TITLE
fix(render): reactively sync template component data via setup()+watchEffect 

### DIFF
--- a/fe/packages/render/src/core/runtime.js
+++ b/fe/packages/render/src/core/runtime.js
@@ -29,6 +29,7 @@ import {
 	Suspense,
 	toDisplayString,
 	watch,
+	watchEffect,
 	withCtx,
 	withDirectives,
 } from 'vue'
@@ -104,17 +105,13 @@ class Runtime {
 				},
 				setup(props) {
 					const state = reactive({})
-					watch(
-						() => props.data,
-						(newData) => {
-							if (newData) {
-								for (const key in newData) {
-									state[key] = newData[key]
-								}
-							}
-						},
-						{ immediate: true },
-					)
+					watchEffect(() => {
+						const newData = props.data || {}
+						for (const key in state) {
+							if (!(key in newData)) delete state[key]
+						}
+						Object.assign(state, newData)
+					})
 					return state
 				},
 				render,

--- a/fe/packages/render/src/core/runtime.js
+++ b/fe/packages/render/src/core/runtime.js
@@ -102,10 +102,20 @@ class Runtime {
 				props: {
 					data: Object,
 				},
-				data() {
-					return {
-						...this.data,
-					}
+				setup(props) {
+					const state = reactive({})
+					watch(
+						() => props.data,
+						(newData) => {
+							if (newData) {
+								for (const key in newData) {
+									state[key] = newData[key]
+								}
+							}
+						},
+						{ immediate: true },
+					)
+					return state
 				},
 				render,
 			})


### PR DESCRIPTION
data() 仅在组件创建时执行一次。当父组件 v-for 通过 setData 替换子数组时，Vue 按 key 复用旧组件实例，但本地数据仍持有旧引用，导致渲染不更新。

该问题在 Taro + Vue 小程序中复现：base.wxml 递归模板 + 路径式 setData（如 root.cn.[0].cn.[2].cn）