### PR TITLE
feat: list custom APIs from registerApi in Object.keys(wx)

### DIFF
--- a/android/dimina/src/main/kotlin/com/didi/dimina/core/MiniApp.kt
+++ b/android/dimina/src/main/kotlin/com/didi/dimina/core/MiniApp.kt
@@ -144,14 +144,14 @@ class MiniApp private constructor() {
                                 // Inject custom API namespaces before loading service.js
                                 val namespaces = Dimina.getInstance().getApiNamespaces()
                                 if (namespaces.isNotEmpty()) {
-                                    val json = namespaces.joinToString(",") { "\"$it\"" }
-                                    evaluate("globalThis.__diminaApiNamespaces = [$json]")
+                                    val json = org.json.JSONArray(namespaces).toString()
+                                    evaluate("globalThis.__diminaApiNamespaces = $json")
                                 }
-                                // 注入已注册的 API 名字，使 service 层的 wx Proxy 能枚举到它们
+                                // 注入已注册的 API 名字，使 service 层的 wx 对象能枚举到它们
                                 val registeredApis = getAvailableApis()
                                 if (registeredApis.isNotEmpty()) {
-                                    val apisJson = registeredApis.joinToString(",") { "\"$it\"" }
-                                    evaluate("globalThis.__diminaRegisteredApis = [$apisJson]")
+                                    val apisJson = org.json.JSONArray(registeredApis).toString()
+                                    evaluate("globalThis.__diminaRegisteredApis = $apisJson")
                                 }
 
                                 evaluateFromFile(

--- a/android/dimina/src/main/kotlin/com/didi/dimina/core/MiniApp.kt
+++ b/android/dimina/src/main/kotlin/com/didi/dimina/core/MiniApp.kt
@@ -147,6 +147,12 @@ class MiniApp private constructor() {
                                     val json = namespaces.joinToString(",") { "\"$it\"" }
                                     evaluate("globalThis.__diminaApiNamespaces = [$json]")
                                 }
+                                // 注入已注册的 API 名字，使 service 层的 wx Proxy 能枚举到它们
+                                val registeredApis = getAvailableApis()
+                                if (registeredApis.isNotEmpty()) {
+                                    val apisJson = registeredApis.joinToString(",") { "\"$it\"" }
+                                    evaluate("globalThis.__diminaRegisteredApis = [$apisJson]")
+                                }
 
                                 evaluateFromFile(
                                     File(

--- a/fe/packages/container/src/core/jscore.js
+++ b/fe/packages/container/src/core/jscore.js
@@ -13,7 +13,11 @@ export class JSCore {
 		// 使用下面的形式会使 hash 失效
 		// this.worker = new Worker(new URL('@dimina/service', import.meta.url))；
 		const namespaces = this.parent.getApiNamespaces?.() || []
-		const workerName = JSON.stringify({ apiNamespaces: namespaces })
+		// 把已注册的 API 名字随 worker 启动配置传给 service 层，
+		// 使它们在 wx（globalApi Proxy）上可被枚举，
+		// 供 Taro 等按 Object.keys(wx) 建表的框架识别。
+		const registeredApis = Object.keys(this.parent.apiRegistry ?? {})
+		const workerName = JSON.stringify({ apiNamespaces: namespaces, registeredApis })
 		this.worker = new Worker(serviceURL, { type: 'classic', name: workerName })
 
 		// 监听逻辑线程的消息

--- a/fe/packages/service/__tests__/api-enumerable.spec.js
+++ b/fe/packages/service/__tests__/api-enumerable.spec.js
@@ -1,0 +1,170 @@
+/**
+ * Tests for the enumerability contract on globalApi (src/api/index.js):
+ *   - Named export `setEnumerableApiNames(names: string[])` records "virtual"
+ *     API names into an internal Set.
+ *   - Proxy `has` / `ownKeys` / `getOwnPropertyDescriptor` traps make those
+ *     recorded names enumerable on globalApi, so frameworks that build their
+ *     API surface from `Object.keys(wx)` (e.g. Taro) pick them up.
+ *
+ * NOTE: `Object.preventExtensions` is irreversible and the module-level Set
+ * persists across tests within a vitest worker. The non-extensible guard test
+ * MUST be last, and earlier tests use `.includes()` rather than exact-array
+ * equality to accommodate the cumulative Set state.
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Mock heavy transitive dependencies that every core/**/index.js pulls in.
+// @/api/common is the universal dep (invokeAPI); expose it as a vi.fn() so
+// forwarding assertions can be made without touching real message channels.
+// ---------------------------------------------------------------------------
+vi.mock('@/api/common', () => ({
+	invokeAPI: vi.fn(() => 'mocked-result'),
+}))
+
+vi.mock('@dimina/common', () => ({
+	callback: { store: vi.fn(fn => fn) },
+	isFunction: vi.fn(v => typeof v === 'function'),
+	isWebWorker: false,
+	parsePath: vi.fn(p => p),
+	suffixPixel: vi.fn(v => v),
+	uuid: vi.fn(() => 'test-uuid'),
+	modDefine: vi.fn(),
+	modRequire: vi.fn(),
+}))
+
+// ---------------------------------------------------------------------------
+// Import the REAL api/index.js (not a mock) so we exercise the actual Proxy.
+// ---------------------------------------------------------------------------
+import { invokeAPI } from '@/api/common'
+import globalApi, { setEnumerableApiNames } from '../src/api/index.js'
+
+// ---------------------------------------------------------------------------
+// Helper: a name that definitely does not exist in any core/**/index.js
+// ---------------------------------------------------------------------------
+const NOVEL = '__novelCustomApiForTest__'
+const NOVEL_2 = '__novelCustomApiForTest2__'
+
+// ---------------------------------------------------------------------------
+// Seed the virtual names before the describe block so all tests share state.
+// (The implementation stores names in a module-level Set.)
+// ---------------------------------------------------------------------------
+beforeAll(() => {
+	setEnumerableApiNames([NOVEL, NOVEL_2])
+})
+
+afterAll(() => {
+	vi.restoreAllMocks()
+})
+
+describe('globalApi Proxy enumerability contract', () => {
+	// -----------------------------------------------------------------------
+	// 1. Virtual name appears in Object.keys / `in` / getOwnPropertyDescriptor
+	//    Bug caught: ownKeys trap missing or has trap missing → silent failure
+	//    when host code iterates the api object to build a bridge catalogue.
+	// -----------------------------------------------------------------------
+	it('virtual name not in core appears in Object.keys, `in`, and getOwnPropertyDescriptor', () => {
+		expect(Object.keys(globalApi)).toContain(NOVEL)
+		expect(NOVEL in globalApi).toBe(true)
+
+		const desc = Object.getOwnPropertyDescriptor(globalApi, NOVEL)
+		expect(desc).toBeDefined()
+		expect(desc.enumerable).toBe(true)
+		expect(desc.configurable).toBe(true)
+		expect(typeof desc.value).toBe('function')
+	})
+
+	// -----------------------------------------------------------------------
+	// 2. Calling a virtual API forwards to invokeAPI with the correct name.
+	//    Bug caught: get trap returns a stub but does not actually call
+	//    invokeAPI, so cross-layer RPC is never sent.
+	// -----------------------------------------------------------------------
+	it('calling a virtual API forwards to invokeAPI with the correct name and returns its result', () => {
+		vi.mocked(invokeAPI).mockReturnValueOnce('bridge-return')
+
+		const result = globalApi[NOVEL]({ key: 'val' })
+
+		expect(invokeAPI).toHaveBeenCalledWith(NOVEL, { key: 'val' })
+		expect(result).toBe('bridge-return')
+	})
+
+	// -----------------------------------------------------------------------
+	// 3. Each virtual name gets a handler bound to its own name — no closure
+	//    capture bug where all stubs share the last registered name.
+	//    Bug caught: loop over Set closes over a single variable, all stubs
+	//    invoke invokeAPI('__novelCustomApiForTest2__', ...) regardless of
+	//    which property is accessed.
+	// -----------------------------------------------------------------------
+	it('distinct virtual names each forward to invokeAPI with their own name (no closure-capture bug)', () => {
+		vi.mocked(invokeAPI).mockClear()
+
+		globalApi[NOVEL]('arg-a')
+		globalApi[NOVEL_2]('arg-b')
+
+		const calls = vi.mocked(invokeAPI).mock.calls
+		expect(calls[0][0]).toBe(NOVEL)
+		expect(calls[1][0]).toBe(NOVEL_2)
+	})
+
+	// -----------------------------------------------------------------------
+	// 4. Static core API names stay enumerable — no-regression check.
+	//    Bug caught: ownKeys trap returns ONLY the virtual Set, dropping
+	//    all real core APIs from enumeration.
+	// -----------------------------------------------------------------------
+	it('static core API "login" is still enumerable in Object.keys after virtual names are added', () => {
+		expect(Object.keys(globalApi)).toContain('login')
+	})
+
+	// -----------------------------------------------------------------------
+	// 5. A virtual name that collides with a static core API does NOT produce
+	//    a duplicate key in Object.keys.
+	//    Bug caught: ownKeys naively concatenates core keys + Set keys without
+	//    deduplication.
+	// -----------------------------------------------------------------------
+	it('passing a static core API name ("login") to setEnumerableApiNames does not create a duplicate in Object.keys', () => {
+		setEnumerableApiNames(['login'])
+		const keys = Object.keys(globalApi)
+		const loginCount = keys.filter(k => k === 'login').length
+		expect(loginCount).toBe(1)
+	})
+
+	// -----------------------------------------------------------------------
+	// 6. A name never registered and not in core does NOT appear in keys.
+	//    Bug caught: over-broad ownKeys trap returns all possible names or
+	//    the `in` trap always returns true.
+	// -----------------------------------------------------------------------
+	it('a name never passed to setEnumerableApiNames and not in core is absent from Object.keys', () => {
+		const ghost = '__ghostApiNeverRegistered__'
+		expect(Object.keys(globalApi)).not.toContain(ghost)
+		expect(ghost in globalApi).toBe(false)
+	})
+
+	// -----------------------------------------------------------------------
+	// 6b. setEnumerableApiNames ignores Object.prototype member names.
+	//    Bug caught: registering a name like `toString` would be reported as
+	//    an enumerable own API, yet `wx.toString` resolves to the inherited
+	//    Object.prototype.toString — an inconsistency Taro's processApis
+	//    would then wrap incorrectly.
+	// -----------------------------------------------------------------------
+	it('setEnumerableApiNames ignores Object.prototype member names such as "toString"', () => {
+		setEnumerableApiNames(['toString'])
+		expect(Object.keys(globalApi)).not.toContain('toString')
+		expect(Object.getOwnPropertyDescriptor(globalApi, 'toString')).toBeUndefined()
+	})
+
+	// -----------------------------------------------------------------------
+	// 7. Non-extensible guard: after Object.preventExtensions the virtual
+	//    names are no longer reported and `in` returns false.
+	//    Bug caught: ownKeys trap ignores extensibility, leaking virtual names
+	//    after the object is sealed, breaking `for…in` / spread in frozen
+	//    contexts.
+	//
+	//    MUST be last — preventExtensions is irreversible.
+	// -----------------------------------------------------------------------
+	it('after Object.preventExtensions, virtual names are absent from Object.keys and `in` returns false [LAST TEST]', () => {
+		Object.preventExtensions(globalApi)
+
+		expect(Object.keys(globalApi)).not.toContain(NOVEL)
+		expect(NOVEL in globalApi).toBe(false)
+	})
+})

--- a/fe/packages/service/__tests__/api-enumerable.spec.js
+++ b/fe/packages/service/__tests__/api-enumerable.spec.js
@@ -1,15 +1,14 @@
 /**
  * Tests for the enumerability contract on globalApi (src/api/index.js):
- *   - Named export `setEnumerableApiNames(names: string[])` records "virtual"
- *     API names into an internal Set.
- *   - Proxy `has` / `ownKeys` / `getOwnPropertyDescriptor` traps make those
- *     recorded names enumerable on globalApi, so frameworks that build their
- *     API surface from `Object.keys(wx)` (e.g. Taro) pick them up.
- *
- * NOTE: `Object.preventExtensions` is irreversible and the module-level Set
- * persists across tests within a vitest worker. The non-extensible guard test
- * MUST be last, and earlier tests use `.includes()` rather than exact-array
- * equality to accommodate the cumulative Set state.
+ *   - Named export `registerEnumerableApiNames(names: string[])` defines
+ *     each name as a real own enumerable property on the underlying api
+ *     object via Object.defineProperty.
+ *   - Because the Proxy does not trap ownKeys / getOwnPropertyDescriptor,
+ *     these properties are reflected through to globalApi, so frameworks
+ *     that build their API surface from `Object.keys(wx)` (e.g. Taro)
+ *     pick them up.
+ *   - Calls still flow through invokeAPI, identical to the historical
+ *     get-trap fallback behaviour for names not present in core/.
  */
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
@@ -37,7 +36,7 @@ vi.mock('@dimina/common', () => ({
 // Import the REAL api/index.js (not a mock) so we exercise the actual Proxy.
 // ---------------------------------------------------------------------------
 import { invokeAPI } from '@/api/common'
-import globalApi, { setEnumerableApiNames } from '../src/api/index.js'
+import globalApi, { registerEnumerableApiNames } from '../src/api/index.js'
 
 // ---------------------------------------------------------------------------
 // Helper: a name that definitely does not exist in any core/**/index.js
@@ -46,24 +45,25 @@ const NOVEL = '__novelCustomApiForTest__'
 const NOVEL_2 = '__novelCustomApiForTest2__'
 
 // ---------------------------------------------------------------------------
-// Seed the virtual names before the describe block so all tests share state.
-// (The implementation stores names in a module-level Set.)
+// Seed the names before the describe block. Since registration writes real
+// own properties on the shared api object, state persists across tests.
 // ---------------------------------------------------------------------------
 beforeAll(() => {
-	setEnumerableApiNames([NOVEL, NOVEL_2])
+	registerEnumerableApiNames([NOVEL, NOVEL_2])
 })
 
 afterAll(() => {
 	vi.restoreAllMocks()
 })
 
-describe('globalApi Proxy enumerability contract', () => {
+describe('globalApi enumerability contract', () => {
 	// -----------------------------------------------------------------------
-	// 1. Virtual name appears in Object.keys / `in` / getOwnPropertyDescriptor
-	//    Bug caught: ownKeys trap missing or has trap missing → silent failure
-	//    when host code iterates the api object to build a bridge catalogue.
+	// 1. Registered name appears in Object.keys / `in` / getOwnPropertyDescriptor
+	//    Bug caught: registration silently failed to define an own property,
+	//    so host code iterating the api object to build a bridge catalogue
+	//    would miss it.
 	// -----------------------------------------------------------------------
-	it('virtual name not in core appears in Object.keys, `in`, and getOwnPropertyDescriptor', () => {
+	it('registered name appears in Object.keys, `in`, and getOwnPropertyDescriptor', () => {
 		expect(Object.keys(globalApi)).toContain(NOVEL)
 		expect(NOVEL in globalApi).toBe(true)
 
@@ -75,11 +75,11 @@ describe('globalApi Proxy enumerability contract', () => {
 	})
 
 	// -----------------------------------------------------------------------
-	// 2. Calling a virtual API forwards to invokeAPI with the correct name.
-	//    Bug caught: get trap returns a stub but does not actually call
-	//    invokeAPI, so cross-layer RPC is never sent.
+	// 2. Calling a registered API forwards to invokeAPI with the correct name.
+	//    Bug caught: defined property returns a stub but does not actually
+	//    call invokeAPI, so cross-layer RPC is never sent.
 	// -----------------------------------------------------------------------
-	it('calling a virtual API forwards to invokeAPI with the correct name and returns its result', () => {
+	it('calling a registered API forwards to invokeAPI with the correct name and returns its result', () => {
 		vi.mocked(invokeAPI).mockReturnValueOnce('bridge-return')
 
 		const result = globalApi[NOVEL]({ key: 'val' })
@@ -89,13 +89,13 @@ describe('globalApi Proxy enumerability contract', () => {
 	})
 
 	// -----------------------------------------------------------------------
-	// 3. Each virtual name gets a handler bound to its own name — no closure
-	//    capture bug where all stubs share the last registered name.
-	//    Bug caught: loop over Set closes over a single variable, all stubs
+	// 3. Each registered name gets a handler bound to its own name — no
+	//    closure-capture bug where all stubs share the last registered name.
+	//    Bug caught: loop closes over a single mutating variable, all stubs
 	//    invoke invokeAPI('__novelCustomApiForTest2__', ...) regardless of
 	//    which property is accessed.
 	// -----------------------------------------------------------------------
-	it('distinct virtual names each forward to invokeAPI with their own name (no closure-capture bug)', () => {
+	it('distinct registered names each forward to invokeAPI with their own name (no closure-capture bug)', () => {
 		vi.mocked(invokeAPI).mockClear()
 
 		globalApi[NOVEL]('arg-a')
@@ -108,63 +108,47 @@ describe('globalApi Proxy enumerability contract', () => {
 
 	// -----------------------------------------------------------------------
 	// 4. Static core API names stay enumerable — no-regression check.
-	//    Bug caught: ownKeys trap returns ONLY the virtual Set, dropping
-	//    all real core APIs from enumeration.
 	// -----------------------------------------------------------------------
-	it('static core API "login" is still enumerable in Object.keys after virtual names are added', () => {
+	it('static core API "login" is still enumerable in Object.keys after registration', () => {
 		expect(Object.keys(globalApi)).toContain('login')
 	})
 
 	// -----------------------------------------------------------------------
-	// 5. A virtual name that collides with a static core API does NOT produce
-	//    a duplicate key in Object.keys.
-	//    Bug caught: ownKeys naively concatenates core keys + Set keys without
-	//    deduplication.
+	// 5. A registered name that collides with a static core API does NOT
+	//    overwrite the core implementation and does NOT produce a duplicate
+	//    key in Object.keys.
+	//    Bug caught: registration overrides an in-tree implementation with a
+	//    bare invokeAPI forwarder, silently breaking the real behaviour.
 	// -----------------------------------------------------------------------
-	it('passing a static core API name ("login") to setEnumerableApiNames does not create a duplicate in Object.keys', () => {
-		setEnumerableApiNames(['login'])
+	it('passing a static core API name ("login") to registerEnumerableApiNames does not duplicate or override it', () => {
+		const descBefore = Object.getOwnPropertyDescriptor(globalApi, 'login')
+		registerEnumerableApiNames(['login'])
+		const descAfter = Object.getOwnPropertyDescriptor(globalApi, 'login')
+		expect(descAfter.value).toBe(descBefore.value)
+
 		const keys = Object.keys(globalApi)
-		const loginCount = keys.filter(k => k === 'login').length
-		expect(loginCount).toBe(1)
+		expect(keys.filter(k => k === 'login').length).toBe(1)
 	})
 
 	// -----------------------------------------------------------------------
 	// 6. A name never registered and not in core does NOT appear in keys.
-	//    Bug caught: over-broad ownKeys trap returns all possible names or
-	//    the `in` trap always returns true.
 	// -----------------------------------------------------------------------
-	it('a name never passed to setEnumerableApiNames and not in core is absent from Object.keys', () => {
+	it('a name never passed to registerEnumerableApiNames and not in core is absent from Object.keys', () => {
 		const ghost = '__ghostApiNeverRegistered__'
 		expect(Object.keys(globalApi)).not.toContain(ghost)
 		expect(ghost in globalApi).toBe(false)
 	})
 
 	// -----------------------------------------------------------------------
-	// 6b. setEnumerableApiNames ignores Object.prototype member names.
-	//    Bug caught: registering a name like `toString` would be reported as
-	//    an enumerable own API, yet `wx.toString` resolves to the inherited
-	//    Object.prototype.toString — an inconsistency Taro's processApis
-	//    would then wrap incorrectly.
+	// 6b. registerEnumerableApiNames ignores Object.prototype member names.
+	//     Bug caught: registering a name like `toString` would shadow
+	//     Object.prototype.toString with a bare invokeAPI forwarder, breaking
+	//     anything that relies on the inherited implementation.
 	// -----------------------------------------------------------------------
-	it('setEnumerableApiNames ignores Object.prototype member names such as "toString"', () => {
-		setEnumerableApiNames(['toString'])
+	it('registerEnumerableApiNames ignores Object.prototype member names such as "toString"', () => {
+		registerEnumerableApiNames(['toString'])
 		expect(Object.keys(globalApi)).not.toContain('toString')
+		// toString is still inherited from Object.prototype, not an own prop.
 		expect(Object.getOwnPropertyDescriptor(globalApi, 'toString')).toBeUndefined()
-	})
-
-	// -----------------------------------------------------------------------
-	// 7. Non-extensible guard: after Object.preventExtensions the virtual
-	//    names are no longer reported and `in` returns false.
-	//    Bug caught: ownKeys trap ignores extensibility, leaking virtual names
-	//    after the object is sealed, breaking `for…in` / spread in frozen
-	//    contexts.
-	//
-	//    MUST be last — preventExtensions is irreversible.
-	// -----------------------------------------------------------------------
-	it('after Object.preventExtensions, virtual names are absent from Object.keys and `in` returns false [LAST TEST]', () => {
-		Object.preventExtensions(globalApi)
-
-		expect(Object.keys(globalApi)).not.toContain(NOVEL)
-		expect(NOVEL in globalApi).toBe(false)
 	})
 })

--- a/fe/packages/service/__tests__/env.spec.js
+++ b/fe/packages/service/__tests__/env.spec.js
@@ -2,10 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Mock all heavy dependencies — we only care about the namespace logic
 const mockGlobalApi = { __mock: true }
-// setEnumerableApiNames is a named export of ../src/api; mock it here so
+// registerEnumerableApiNames is a named export of ../src/api; mock it here so
 // env.js can import it, and so we can assert env.init() forwards the
 // registeredApis list to it.
-const mockSetEnumerableApiNames = vi.fn()
+const mockRegisterEnumerableApiNames = vi.fn()
 
 vi.mock('@dimina/common', () => ({
 	modDefine: vi.fn(),
@@ -13,7 +13,7 @@ vi.mock('@dimina/common', () => ({
 }))
 vi.mock('../src/api', () => ({
 	default: mockGlobalApi,
-	setEnumerableApiNames: mockSetEnumerableApiNames,
+	registerEnumerableApiNames: mockRegisterEnumerableApiNames,
 }))
 vi.mock('../src/instance/component/component-module', () => ({ ComponentModule: { type: 'component' } }))
 vi.mock('../src/instance/page/page-module', () => ({ PageModule: { type: 'page' } }))
@@ -32,7 +32,7 @@ describe('env.js API namespace registration', () => {
 		delete globalThis.wx
 		// Simulate Worker's self (not available in Node)
 		globalThis.self = { name: '' }
-		mockSetEnumerableApiNames.mockClear()
+		mockRegisterEnumerableApiNames.mockClear()
 	})
 
 	afterEach(() => {
@@ -96,17 +96,17 @@ describe('env.js API namespace registration', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Tests for the registeredApis → setEnumerableApiNames forwarding: env.js
+// Tests for the registeredApis → registerEnumerableApiNames forwarding: env.js
 // reads __diminaRegisteredApis / globalThis.name.registeredApis and calls
-// setEnumerableApiNames with the result.
+// registerEnumerableApiNames with the result.
 // ---------------------------------------------------------------------------
-describe('env.js registeredApis → setEnumerableApiNames forwarding', () => {
+describe('env.js registeredApis → registerEnumerableApiNames forwarding', () => {
 	beforeEach(() => {
 		delete globalThis.__diminaRegisteredApis
 		delete globalThis.__diminaApiNamespaces
 		delete globalThis.name
 		globalThis.self = { name: '' }
-		mockSetEnumerableApiNames.mockClear()
+		mockRegisterEnumerableApiNames.mockClear()
 	})
 
 	afterEach(() => {
@@ -117,24 +117,24 @@ describe('env.js registeredApis → setEnumerableApiNames forwarding', () => {
 	// Bug caught: env.js never reads __diminaRegisteredApis, so custom APIs
 	// injected by the host container are never made enumerable on globalApi.
 	// -----------------------------------------------------------------------
-	it('should call setEnumerableApiNames with names from __diminaRegisteredApis (native global source)', async () => {
+	it('should call registerEnumerableApiNames with names from __diminaRegisteredApis (native global source)', async () => {
 		globalThis.__diminaRegisteredApis = ['myCustomPay', 'myCustomLogin']
 
 		await import('../src/core/env.js')
 
-		expect(mockSetEnumerableApiNames).toHaveBeenCalledWith(['myCustomPay', 'myCustomLogin'])
+		expect(mockRegisterEnumerableApiNames).toHaveBeenCalledWith(['myCustomPay', 'myCustomLogin'])
 	})
 
 	// -----------------------------------------------------------------------
 	// Bug caught: env.js falls back to self.name for apiNamespaces but does
 	// not do the same for registeredApis, so JSON-encoded config is ignored.
 	// -----------------------------------------------------------------------
-	it('should call setEnumerableApiNames with names from self.name JSON when __diminaRegisteredApis is absent (JSON fallback source)', async () => {
+	it('should call registerEnumerableApiNames with names from self.name JSON when __diminaRegisteredApis is absent (JSON fallback source)', async () => {
 		globalThis.name = JSON.stringify({ registeredApis: ['jsonApi1', 'jsonApi2'] })
 
 		await import('../src/core/env.js')
 
-		expect(mockSetEnumerableApiNames).toHaveBeenCalledWith(['jsonApi1', 'jsonApi2'])
+		expect(mockRegisterEnumerableApiNames).toHaveBeenCalledWith(['jsonApi1', 'jsonApi2'])
 	})
 
 	// -----------------------------------------------------------------------
@@ -147,26 +147,26 @@ describe('env.js registeredApis → setEnumerableApiNames forwarding', () => {
 
 		await import('../src/core/env.js')
 
-		const calls = mockSetEnumerableApiNames.mock.calls
+		const calls = mockRegisterEnumerableApiNames.mock.calls
 		// Must have been called exactly with the native list, not the JSON list
 		expect(calls.some(call => JSON.stringify(call[0]) === JSON.stringify(['nativeApi']))).toBe(true)
 		expect(calls.every(call => !call[0].includes('jsonApi'))).toBe(true)
 	})
 
 	// -----------------------------------------------------------------------
-	// Bug caught: setEnumerableApiNames is called with undefined or null when
+	// Bug caught: registerEnumerableApiNames is called with undefined or null when
 	// neither source provides registeredApis, corrupting the internal Set.
 	// -----------------------------------------------------------------------
-	it('should call setEnumerableApiNames with an empty array when neither source provides registeredApis', async () => {
+	it('should call registerEnumerableApiNames with an empty array when neither source provides registeredApis', async () => {
 		// Neither __diminaRegisteredApis nor self.name.registeredApis is set
 		globalThis.__diminaRegisteredApis = undefined
 		globalThis.name = JSON.stringify({ apiNamespaces: ['qd'] }) // no registeredApis key
 
 		await import('../src/core/env.js')
 
-		// setEnumerableApiNames must be called (not skipped) and must receive []
-		expect(mockSetEnumerableApiNames).toHaveBeenCalled()
-		const firstCall = mockSetEnumerableApiNames.mock.calls[0]
+		// registerEnumerableApiNames must be called (not skipped) and must receive []
+		expect(mockRegisterEnumerableApiNames).toHaveBeenCalled()
+		const firstCall = mockRegisterEnumerableApiNames.mock.calls[0]
 		expect(firstCall[0]).toEqual([])
 	})
 })

--- a/fe/packages/service/__tests__/env.spec.js
+++ b/fe/packages/service/__tests__/env.spec.js
@@ -2,12 +2,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Mock all heavy dependencies — we only care about the namespace logic
 const mockGlobalApi = { __mock: true }
+// setEnumerableApiNames is a named export of ../src/api; mock it here so
+// env.js can import it, and so we can assert env.init() forwards the
+// registeredApis list to it.
+const mockSetEnumerableApiNames = vi.fn()
 
 vi.mock('@dimina/common', () => ({
 	modDefine: vi.fn(),
 	modRequire: vi.fn(),
 }))
-vi.mock('../src/api', () => ({ default: mockGlobalApi }))
+vi.mock('../src/api', () => ({
+	default: mockGlobalApi,
+	setEnumerableApiNames: mockSetEnumerableApiNames,
+}))
 vi.mock('../src/instance/component/component-module', () => ({ ComponentModule: { type: 'component' } }))
 vi.mock('../src/instance/page/page-module', () => ({ PageModule: { type: 'page' } }))
 vi.mock('../src/core/loader', () => ({ default: { createAppModule: vi.fn(), createModule: vi.fn() } }))
@@ -18,12 +25,14 @@ describe('env.js API namespace registration', () => {
 	beforeEach(() => {
 		// Clean up namespace-related globals before each test
 		delete globalThis.__diminaApiNamespaces
+		delete globalThis.__diminaRegisteredApis
 		delete globalThis.qd
 		delete globalThis.myapp
 		delete globalThis.dd
 		delete globalThis.wx
 		// Simulate Worker's self (not available in Node)
 		globalThis.self = { name: '' }
+		mockSetEnumerableApiNames.mockClear()
 	})
 
 	afterEach(() => {
@@ -83,5 +92,81 @@ describe('env.js API namespace registration', () => {
 
 		expect(globalThis.qd).toBe(mockGlobalApi)
 		expect(globalThis.myapp).toBeUndefined()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Tests for the registeredApis → setEnumerableApiNames forwarding: env.js
+// reads __diminaRegisteredApis / globalThis.name.registeredApis and calls
+// setEnumerableApiNames with the result.
+// ---------------------------------------------------------------------------
+describe('env.js registeredApis → setEnumerableApiNames forwarding', () => {
+	beforeEach(() => {
+		delete globalThis.__diminaRegisteredApis
+		delete globalThis.__diminaApiNamespaces
+		delete globalThis.name
+		globalThis.self = { name: '' }
+		mockSetEnumerableApiNames.mockClear()
+	})
+
+	afterEach(() => {
+		vi.resetModules()
+	})
+
+	// -----------------------------------------------------------------------
+	// Bug caught: env.js never reads __diminaRegisteredApis, so custom APIs
+	// injected by the host container are never made enumerable on globalApi.
+	// -----------------------------------------------------------------------
+	it('should call setEnumerableApiNames with names from __diminaRegisteredApis (native global source)', async () => {
+		globalThis.__diminaRegisteredApis = ['myCustomPay', 'myCustomLogin']
+
+		await import('../src/core/env.js')
+
+		expect(mockSetEnumerableApiNames).toHaveBeenCalledWith(['myCustomPay', 'myCustomLogin'])
+	})
+
+	// -----------------------------------------------------------------------
+	// Bug caught: env.js falls back to self.name for apiNamespaces but does
+	// not do the same for registeredApis, so JSON-encoded config is ignored.
+	// -----------------------------------------------------------------------
+	it('should call setEnumerableApiNames with names from self.name JSON when __diminaRegisteredApis is absent (JSON fallback source)', async () => {
+		globalThis.name = JSON.stringify({ registeredApis: ['jsonApi1', 'jsonApi2'] })
+
+		await import('../src/core/env.js')
+
+		expect(mockSetEnumerableApiNames).toHaveBeenCalledWith(['jsonApi1', 'jsonApi2'])
+	})
+
+	// -----------------------------------------------------------------------
+	// Bug caught: __diminaRegisteredApis is present but ignored in favour of
+	// the JSON config, causing stale or wrong API lists to be registered.
+	// -----------------------------------------------------------------------
+	it('should prefer __diminaRegisteredApis over self.name registeredApis when both are present', async () => {
+		globalThis.__diminaRegisteredApis = ['nativeApi']
+		globalThis.name = JSON.stringify({ registeredApis: ['jsonApi'] })
+
+		await import('../src/core/env.js')
+
+		const calls = mockSetEnumerableApiNames.mock.calls
+		// Must have been called exactly with the native list, not the JSON list
+		expect(calls.some(call => JSON.stringify(call[0]) === JSON.stringify(['nativeApi']))).toBe(true)
+		expect(calls.every(call => !call[0].includes('jsonApi'))).toBe(true)
+	})
+
+	// -----------------------------------------------------------------------
+	// Bug caught: setEnumerableApiNames is called with undefined or null when
+	// neither source provides registeredApis, corrupting the internal Set.
+	// -----------------------------------------------------------------------
+	it('should call setEnumerableApiNames with an empty array when neither source provides registeredApis', async () => {
+		// Neither __diminaRegisteredApis nor self.name.registeredApis is set
+		globalThis.__diminaRegisteredApis = undefined
+		globalThis.name = JSON.stringify({ apiNamespaces: ['qd'] }) // no registeredApis key
+
+		await import('../src/core/env.js')
+
+		// setEnumerableApiNames must be called (not skipped) and must receive []
+		expect(mockSetEnumerableApiNames).toHaveBeenCalled()
+		const firstCall = mockSetEnumerableApiNames.mock.calls[0]
+		expect(firstCall[0]).toEqual([])
 	})
 })

--- a/fe/packages/service/src/api/index.js
+++ b/fe/packages/service/src/api/index.js
@@ -8,20 +8,25 @@ for (const f of Object.values(apiInfo)) {
 	}
 }
 
-// 登记一批由容器/原生侧承接、core 目录里无实现的 API 名字。
-// get 拦截器本就把未知名字转发给 invokeAPI，故它们一直可调用；
-// 下面三个拦截器再让它们可枚举、可被 in 命中，
-// 使按 Object.keys(wx) 建表的框架（如 Taro）也能识别。
-// 与 Object.prototype 成员（toString 等）重名的登记名会被忽略。
-const enumerableApiNames = new Set()
-
-export function setEnumerableApiNames(names) {
+// 把容器/原生侧承接、core 目录里无实现的 API 名字登记成 api 上真实的
+// own enumerable property，让 Object.keys(wx) 能直接枚举到它们，
+// 供 Taro 等按 Object.keys(wx) 建表的框架识别。
+// 撞 Object.prototype 成员（toString 等）或与已有实现重名的名字直接跳过。
+export function registerEnumerableApiNames(names) {
 	for (const name of names || []) {
-		// 撞 Object.prototype 成员的名字直接忽略：get 拦截器会沿原型链
-		// 返回内置实现而非转发函数，登记它只会造成枚举与取值不一致。
-		if (typeof name === 'string' && !(name in Object.prototype)) {
-			enumerableApiNames.add(name)
+		if (
+			typeof name !== 'string'
+			|| Object.prototype.hasOwnProperty.call(api, name)
+			|| name in Object.prototype
+		) {
+			continue
 		}
+		Object.defineProperty(api, name, {
+			value: (...args) => invokeAPI(name, ...args),
+			writable: true,
+			enumerable: true,
+			configurable: true,
+		})
 	}
 }
 
@@ -47,45 +52,6 @@ const handler = {
 	set(target, prop, value, receiver) {
 		// 允许对target对象进行属性赋值
 		return Reflect.set(target, prop, value, receiver)
-	},
-	has(target, prop) {
-		if (Reflect.has(target, prop)) {
-			return true
-		}
-		// 仅当 target 仍可扩展时才暴露这些虚拟名字；对象冻结后保持与自身属性一致
-		return Reflect.isExtensible(target)
-			&& typeof prop === 'string'
-			&& enumerableApiNames.has(prop)
-	},
-	ownKeys(target) {
-		const keys = Reflect.ownKeys(target)
-		// target 不可扩展时，ownKeys 必须只返回它自身的 key（Proxy 不变量要求）
-		if (!Reflect.isExtensible(target)) {
-			return keys
-		}
-		for (const name of enumerableApiNames) {
-			if (!Object.prototype.hasOwnProperty.call(target, name)) {
-				keys.push(name)
-			}
-		}
-		return keys
-	},
-	getOwnPropertyDescriptor(target, prop) {
-		const desc = Reflect.getOwnPropertyDescriptor(target, prop)
-		if (desc !== undefined) {
-			return desc
-		}
-		if (Reflect.isExtensible(target)
-			&& typeof prop === 'string'
-			&& enumerableApiNames.has(prop)) {
-			return {
-				value: (...args) => invokeAPI(prop, ...args),
-				writable: true,
-				enumerable: true,
-				configurable: true,
-			}
-		}
-		return undefined
 	},
 }
 /**

--- a/fe/packages/service/src/api/index.js
+++ b/fe/packages/service/src/api/index.js
@@ -7,6 +7,24 @@ for (const f of Object.values(apiInfo)) {
 		api[k] = v
 	}
 }
+
+// 登记一批由容器/原生侧承接、core 目录里无实现的 API 名字。
+// get 拦截器本就把未知名字转发给 invokeAPI，故它们一直可调用；
+// 下面三个拦截器再让它们可枚举、可被 in 命中，
+// 使按 Object.keys(wx) 建表的框架（如 Taro）也能识别。
+// 与 Object.prototype 成员（toString 等）重名的登记名会被忽略。
+const enumerableApiNames = new Set()
+
+export function setEnumerableApiNames(names) {
+	for (const name of names || []) {
+		// 撞 Object.prototype 成员的名字直接忽略：get 拦截器会沿原型链
+		// 返回内置实现而非转发函数，登记它只会造成枚举与取值不一致。
+		if (typeof name === 'string' && !(name in Object.prototype)) {
+			enumerableApiNames.add(name)
+		}
+	}
+}
+
 const handler = {
 	get(target, prop, receiver) {
 		const origMethod = Reflect.get(target, prop, receiver)
@@ -29,6 +47,45 @@ const handler = {
 	set(target, prop, value, receiver) {
 		// 允许对target对象进行属性赋值
 		return Reflect.set(target, prop, value, receiver)
+	},
+	has(target, prop) {
+		if (Reflect.has(target, prop)) {
+			return true
+		}
+		// 仅当 target 仍可扩展时才暴露这些虚拟名字；对象冻结后保持与自身属性一致
+		return Reflect.isExtensible(target)
+			&& typeof prop === 'string'
+			&& enumerableApiNames.has(prop)
+	},
+	ownKeys(target) {
+		const keys = Reflect.ownKeys(target)
+		// target 不可扩展时，ownKeys 必须只返回它自身的 key（Proxy 不变量要求）
+		if (!Reflect.isExtensible(target)) {
+			return keys
+		}
+		for (const name of enumerableApiNames) {
+			if (!Object.prototype.hasOwnProperty.call(target, name)) {
+				keys.push(name)
+			}
+		}
+		return keys
+	},
+	getOwnPropertyDescriptor(target, prop) {
+		const desc = Reflect.getOwnPropertyDescriptor(target, prop)
+		if (desc !== undefined) {
+			return desc
+		}
+		if (Reflect.isExtensible(target)
+			&& typeof prop === 'string'
+			&& enumerableApiNames.has(prop)) {
+			return {
+				value: (...args) => invokeAPI(prop, ...args),
+				writable: true,
+				enumerable: true,
+				configurable: true,
+			}
+		}
+		return undefined
 	},
 }
 /**

--- a/fe/packages/service/src/core/env.js
+++ b/fe/packages/service/src/core/env.js
@@ -1,5 +1,5 @@
 import { modDefine, modRequire } from '@dimina/common'
-import globalApi from '../api'
+import globalApi, { setEnumerableApiNames } from '../api'
 import { ComponentModule } from '../instance/component/component-module'
 import { PageModule } from '../instance/page/page-module'
 import loader from './loader'
@@ -14,12 +14,20 @@ class Env {
 	init() {
 		// Register API namespaces (dd, wx are built-in; custom ones from config)
 		let customNamespaces = globalThis.__diminaApiNamespaces || []
-		if (customNamespaces.length === 0 && globalThis.name) {
+		// 容器/原生侧已注册的 API 名字列表，供 globalApi Proxy 枚举使用（详见 ../api）
+		let registeredApis = globalThis.__diminaRegisteredApis || []
+		if (globalThis.name) {
 			try {
 				const config = JSON.parse(globalThis.name)
-				customNamespaces = config.apiNamespaces || []
+				if (customNamespaces.length === 0) {
+					customNamespaces = config.apiNamespaces || []
+				}
+				if (registeredApis.length === 0) {
+					registeredApis = config.registeredApis || []
+				}
 			} catch (e) {}
 		}
+		setEnumerableApiNames(registeredApis)
 		for (const name of ['dd', 'wx', ...customNamespaces]) {
 			globalThis[name] = globalApi
 		}

--- a/fe/packages/service/src/core/env.js
+++ b/fe/packages/service/src/core/env.js
@@ -1,5 +1,5 @@
 import { modDefine, modRequire } from '@dimina/common'
-import globalApi, { setEnumerableApiNames } from '../api'
+import globalApi, { registerEnumerableApiNames } from '../api'
 import { ComponentModule } from '../instance/component/component-module'
 import { PageModule } from '../instance/page/page-module'
 import loader from './loader'
@@ -27,7 +27,7 @@ class Env {
 				}
 			} catch (e) {}
 		}
-		setEnumerableApiNames(registeredApis)
+		registerEnumerableApiNames(registeredApis)
 		for (const name of ['dd', 'wx', ...customNamespaces]) {
 			globalThis[name] = globalApi
 		}

--- a/harmony/dimina/src/main/ets/Bridges/DMPModuleManager.ets
+++ b/harmony/dimina/src/main/ets/Bridges/DMPModuleManager.ets
@@ -9,6 +9,14 @@ import { DMPMap } from '../Utils/DMPMap';
 export abstract class DMPModuleManager {
   abstract exportModules: Map<string, DMPExportModule>
 
+  /** 累积已注册的 API 方法名，供 service 层 wx Proxy 枚举使用 */
+  registeredApiNames: string[] = []
+
+  /** 返回所有已注册的 API 方法名（已去重） */
+  getAllRegisteredApiNames(): string[] {
+    return Array.from(new Set(this.registeredApiNames))
+  }
+
   registerModule(moduleObject: DMPContainerBridgesModule) {
     this.registerModuleByName(moduleObject, 'DMPContainerBridgesModule')
   }
@@ -80,6 +88,7 @@ export abstract class DMPModuleManager {
       const exportMethods = module.exportMethods
       methodList.forEach((methodName) => {
         exportMethods[methodName] = moduleObject
+        this.registeredApiNames.push(methodName)
       })
     }
   }

--- a/harmony/dimina/src/main/ets/DApp/DMPApp.ets
+++ b/harmony/dimina/src/main/ets/DApp/DMPApp.ets
@@ -404,6 +404,12 @@ export class DMPApp {
       const json = namespaces.map((n: string) => `"${n}"`).join(",")
       this._service.executeScript(`globalThis.__diminaApiNamespaces = [${json}]`)
     }
+    // 注入已注册的 API 名字，使 service 层的 wx Proxy 能枚举到它们
+    const registeredApis = this._appModuleManager.getAllRegisteredApiNames()
+    if (registeredApis.length > 0) {
+      const apisJson = registeredApis.map((n: string) => `"${n}"`).join(",")
+      this._service.executeScript(`globalThis.__diminaRegisteredApis = [${apisJson}]`)
+    }
     const serviceJsPath = await this._bundleManager.requestServiceJsUri();
     await this._service.loadFileUri(serviceJsPath);
     DMPLogger.i(Tags.LAUNCH, "startEngineService end");

--- a/harmony/dimina/src/main/ets/DApp/DMPApp.ets
+++ b/harmony/dimina/src/main/ets/DApp/DMPApp.ets
@@ -401,14 +401,14 @@ export class DMPApp {
     // Inject custom API namespaces before loading service.js
     const namespaces = DMPApp._apiNamespaces
     if (namespaces.length > 0) {
-      const json = namespaces.map((n: string) => `"${n}"`).join(",")
-      this._service.executeScript(`globalThis.__diminaApiNamespaces = [${json}]`)
+      const json = JSON.stringify(namespaces)
+      this._service.executeScript(`globalThis.__diminaApiNamespaces = ${json}`)
     }
-    // 注入已注册的 API 名字，使 service 层的 wx Proxy 能枚举到它们
+    // 注入已注册的 API 名字，使 service 层的 wx 对象能枚举到它们
     const registeredApis = this._appModuleManager.getAllRegisteredApiNames()
     if (registeredApis.length > 0) {
-      const apisJson = registeredApis.map((n: string) => `"${n}"`).join(",")
-      this._service.executeScript(`globalThis.__diminaRegisteredApis = [${apisJson}]`)
+      const apisJson = JSON.stringify(registeredApis)
+      this._service.executeScript(`globalThis.__diminaRegisteredApis = ${apisJson}`)
     }
     const serviceJsPath = await this._bundleManager.requestServiceJsUri();
     await this._service.loadFileUri(serviceJsPath);

--- a/iOS/dimina/DiminaKit/App/DMPApp.swift
+++ b/iOS/dimina/DiminaKit/App/DMPApp.swift
@@ -137,15 +137,17 @@ public class DMPApp {
         print("loadBundle")
         // Inject custom API namespaces before loading service.js
         let namespaces = DMPAppManager.sharedInstance().apiNamespaces
-        if !namespaces.isEmpty {
-            let json = namespaces.map { "\"\($0)\"" }.joined(separator: ",")
-            await service?.evaluateScript("globalThis.__diminaApiNamespaces = [\(json)]")
+        if !namespaces.isEmpty,
+           let data = try? JSONSerialization.data(withJSONObject: namespaces),
+           let json = String(data: data, encoding: .utf8) {
+            await service?.evaluateScript("globalThis.__diminaApiNamespaces = \(json)")
         }
-        // 注入已注册的 API 名字，使 service 层的 wx Proxy 能枚举到它们
+        // 注入已注册的 API 名字，使 service 层的 wx 对象能枚举到它们
         let registeredApis = DMPContainerApi.getAllRegisteredMethods()
-        if !registeredApis.isEmpty {
-            let json = registeredApis.map { "\"\($0)\"" }.joined(separator: ",")
-            await service?.evaluateScript("globalThis.__diminaRegisteredApis = [\(json)]")
+        if !registeredApis.isEmpty,
+           let data = try? JSONSerialization.data(withJSONObject: registeredApis),
+           let json = String(data: data, encoding: .utf8) {
+            await service?.evaluateScript("globalThis.__diminaRegisteredApis = \(json)")
         }
         await service?.loadFile(path: DMPSandboxManager.sdkServicePath())
         await service?.loadFile(path: DMPSandboxManager.appServicePath(appId: appId))

--- a/iOS/dimina/DiminaKit/App/DMPApp.swift
+++ b/iOS/dimina/DiminaKit/App/DMPApp.swift
@@ -141,6 +141,12 @@ public class DMPApp {
             let json = namespaces.map { "\"\($0)\"" }.joined(separator: ",")
             await service?.evaluateScript("globalThis.__diminaApiNamespaces = [\(json)]")
         }
+        // 注入已注册的 API 名字，使 service 层的 wx Proxy 能枚举到它们
+        let registeredApis = DMPContainerApi.getAllRegisteredMethods()
+        if !registeredApis.isEmpty {
+            let json = registeredApis.map { "\"\($0)\"" }.joined(separator: ",")
+            await service?.evaluateScript("globalThis.__diminaRegisteredApis = [\(json)]")
+        }
         await service?.loadFile(path: DMPSandboxManager.sdkServicePath())
         await service?.loadFile(path: DMPSandboxManager.appServicePath(appId: appId))
 


### PR DESCRIPTION
问题：

通过 `MiniApp.registerApi` 注册的自定义 API，在小程序中可以通过 `wx.<name>()`调用，但不会出现在 `Object.keys(wx)` 里。

Taro 小程序运行时会由 `@tarojs/shared` 的 `processApis` 根据 `Object.keys(wx)` 一次性生成 `Taro.xxx` 包装。由于自定义API 无法被枚举到，Taro 也不会为它们生成对应的 `Taro.<name>`。这导致无法使用 `Taro.xxx` 调用注册的自定 API。

修复方案：

给 service 层 `wx` 补上 `ownKeys` / `getOwnPropertyDescriptor` / `has` 拦截器，让已注册的自定义 API 名字能被`Object.keys(wx)` 枚举到