### PR TITLE
feat(compiler): build() 支持自定义小程序文件扩展名（fileTypes 选项）

### DIFF
--- a/fe/packages/compiler/README.md
+++ b/fe/packages/compiler/README.md
@@ -126,6 +126,27 @@ miniprogram_npm/      ->  npm包构建   (npm组件支持)
 
 详细使用说明请参考：[TypeScript、Less 和 SCSS 支持文档](./docs/typescript-less-scss-support.md)
 
+### 自定义文件类型（custom file types）
+
+编译器内置识别 `wx*`（`.wxml/.wxss/.wxs`）与 `dd*`（`.ddml/.ddss`）系扩展名。通过编程入口 `build()` 的 `options.fileTypes`，可在内置之上**追加**自定义品牌扩展名（如 `.qdml/.qdss/.qds`），使其与对应内置类型等价编译：
+
+```js
+import build from '@dimina/compiler'
+
+await build(targetPath, workPath, true, {
+  fileTypes: {
+    template: ['qdml'],   // 追加模板扩展名，与 .wxml/.ddml 等价 -> view.js
+    style: ['qdss'],      // 追加样式扩展名，与 .wxss/.ddss 等价 -> style.css
+    viewScript: ['qds'],  // 追加 WXS 类视图脚本：同时覆盖 .qds 文件与内联 <qds> 标签
+  },
+})
+```
+
+- 自动归一化：补前导点、转小写、去重；内置项在前、自定义项在后即查找优先级。
+- 内置 `wx`/`dd` 系永远保留，仅追加不替换。
+- `viewScript` 同时作用于**文件扩展名**（`.qds`）与**内联标签**（`<qds module>`）。
+- CLI 暂未开放对应 flag，自定义文件类型能力通过编程入口注入。
+
 ### npm 组件支持
 
 编译器现已支持微信小程序的 npm 包功能，遵循微信官方的 npm 支持规范：

--- a/fe/packages/compiler/__tests__/custom-file-types.spec.js
+++ b/fe/packages/compiler/__tests__/custom-file-types.spec.js
@@ -1,0 +1,488 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+	getStyleExts,
+	getTemplateExts,
+	getViewScriptExts,
+	getViewScriptTags,
+	resetStoreInfo,
+	storeInfo,
+} from '../src/env.js'
+
+/**
+ * 「可配置小程序自定义文件类型（custom file types）」特性的契约测试。
+ *
+ * 实现尚未存在 —— 这些测试当前应当失败（getter 未导出 / storeInfo 不接受 options）。
+ * 每个测试都对应一个会真实发生的 bug，而不是同义反复。
+ *
+ * 注意：env 是模块级单例，测试之间通过 storeInfo()/resetStoreInfo() 互相影响，
+ * 所以每个 case 都显式重新调用 storeInfo() 建立自己的输入，不依赖上一个 case 的状态。
+ */
+
+let tempDir
+
+function writeProjectFile(filePath, content) {
+	const fullPath = path.join(tempDir, filePath)
+	fs.mkdirSync(path.dirname(fullPath), { recursive: true })
+	fs.writeFileSync(fullPath, content)
+}
+
+/**
+ * 写出一个最小可被 storeInfo() 解析的小程序工程（app.json + 一个页面）。
+ * storeInfo 内部会读取 app.json / project.config.json，缺了会抛错。
+ */
+function prepareMinimalProject() {
+	writeProjectFile('app.json', JSON.stringify({ pages: ['pages/home/index'] }))
+	writeProjectFile('project.config.json', JSON.stringify({ appid: 'custom-test' }))
+	writeProjectFile('pages/home/index.json', JSON.stringify({}))
+	writeProjectFile('pages/home/index.wxml', '<view>home</view>')
+	writeProjectFile('pages/home/index.wxss', '')
+	writeProjectFile('pages/home/index.js', 'Page({})')
+}
+
+describe('custom file types — getters 默认值', () => {
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'custom-default-'))
+		prepareMinimalProject()
+		// 不注入任何 fileTypes，期望落在内置默认值
+		storeInfo(tempDir)
+	})
+
+	afterEach(() => {
+		if (tempDir && fs.existsSync(tempDir)) {
+			fs.rmSync(tempDir, { recursive: true, force: true })
+		}
+	})
+
+	// bug：默认模板扩展名漏掉 dd 系会导致 .ddml 工程编译不出 view.js
+	it('getTemplateExts 默认含内置 .wxml 与 .ddml', () => {
+		expect(getTemplateExts()).toEqual(['.wxml', '.ddml'])
+	})
+
+	// bug：样式默认值漏掉预处理器会导致 .less/.scss 文件被当成未知类型跳过
+	it('getStyleExts 默认含内置样式与预处理器扩展名', () => {
+		expect(getStyleExts()).toEqual(['.wxss', '.ddss', '.less', '.scss', '.sass'])
+	})
+
+	// bug：viewScript 默认值多/少一项会让 .wxs 文件无法被收集
+	it('getViewScriptExts 默认仅含 .wxs', () => {
+		expect(getViewScriptExts()).toEqual(['.wxs'])
+	})
+
+	// bug：内联标签若误带前导点（'.wxs'）则 <wxs> 标签匹配不到
+	it('getViewScriptTags 默认含 wxs 与 dds 且不带前导点', () => {
+		const tags = getViewScriptTags()
+		expect(tags).toEqual(['wxs', 'dds'])
+		for (const tag of tags) {
+			expect(tag.startsWith('.')).toBe(false)
+		}
+	})
+})
+
+describe('custom file types — 注入自定义文件类型', () => {
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'custom-inject-'))
+		prepareMinimalProject()
+	})
+
+	afterEach(() => {
+		if (tempDir && fs.existsSync(tempDir)) {
+			fs.rmSync(tempDir, { recursive: true, force: true })
+		}
+	})
+
+	// bug：注入的自定义模板扩展名没被追加 → .qdml 工程无法识别为模板
+	it('注入 template:[qdml] 后 getTemplateExts 追加 .qdml（内置在前、自定义在后）', () => {
+		storeInfo(tempDir, { fileTypes: { template: ['qdml'] } })
+		expect(getTemplateExts()).toEqual(['.wxml', '.ddml', '.qdml'])
+	})
+
+	// bug：缺少自动补点会让用户传 'qdss' 时永远匹配不到 'foo.qdss'
+	it('注入 style:[qdss]（无点）后 getStyleExts 追加 .qdss', () => {
+		storeInfo(tempDir, { fileTypes: { style: ['qdss'] } })
+		expect(getStyleExts()).toEqual(['.wxss', '.ddss', '.less', '.scss', '.sass', '.qdss'])
+	})
+
+	// bug：viewScript 扩展名注入失败 → .qds 文件不被当作 WXS 类脚本
+	it('注入 viewScript:[qds] 后 getViewScriptExts 追加 .qds', () => {
+		storeInfo(tempDir, { fileTypes: { viewScript: ['qds'] } })
+		expect(getViewScriptExts()).toEqual(['.wxs', '.qds'])
+	})
+
+	// bug：viewScript 注入只更新了扩展名却忘了内联标签 → <qds module> 标签无法解析
+	it('注入 viewScript:[qds] 后 getViewScriptTags 追加 qds（不带点）', () => {
+		storeInfo(tempDir, { fileTypes: { viewScript: ['qds'] } })
+		expect(getViewScriptTags()).toEqual(['wxs', 'dds', 'qds'])
+	})
+
+	// bug：用户已带前导点时如果再补点会得到 '..qdml'
+	it('用户传带前导点的扩展名（.qdml）应被规范化为单个点', () => {
+		storeInfo(tempDir, { fileTypes: { template: ['.qdml'] } })
+		expect(getTemplateExts()).toEqual(['.wxml', '.ddml', '.qdml'])
+	})
+
+	// bug：大小写不一致会让 macOS（大小写不敏感）与 CI（敏感）行为分裂
+	it('扩展名应被转为小写', () => {
+		storeInfo(tempDir, { fileTypes: { template: ['.QDML'] } })
+		expect(getTemplateExts()).toEqual(['.wxml', '.ddml', '.qdml'])
+	})
+
+	// bug：去重缺失 → 用户重复传或与内置撞名会产生重复项，污染查找顺序
+	it('与内置同名或重复传入的扩展名应去重（不产生重复 .wxml）', () => {
+		storeInfo(tempDir, { fileTypes: { template: ['wxml', '.WXML', 'qdml', 'qdml'] } })
+		const exts = getTemplateExts()
+		expect(exts).toEqual(['.wxml', '.ddml', '.qdml'])
+		// 显式断言无重复
+		expect(new Set(exts).size).toBe(exts.length)
+	})
+
+	// bug：空串若被补成 '.' 会匹配任意以点结尾的路径
+	it('空串扩展名应被静默丢弃', () => {
+		storeInfo(tempDir, { fileTypes: { template: ['', '   ', 'qdml'] } })
+		expect(getTemplateExts()).toEqual(['.wxml', '.ddml', '.qdml'])
+	})
+
+	// bug：含路径分隔符的项若被当扩展名拼进 glob 会逃逸出目标目录
+	it('含路径分隔符（/ 或 \\）的项应被静默丢弃', () => {
+		storeInfo(tempDir, { fileTypes: { template: ['a/b', 'c\\d', 'qdml'] } })
+		expect(getTemplateExts()).toEqual(['.wxml', '.ddml', '.qdml'])
+	})
+
+	// bug：viewScript 标签 getter 也必须执行同样的归一化（小写/去重/丢非法）
+	it('viewScript 标签 getter 同样做小写与去重归一化', () => {
+		storeInfo(tempDir, { fileTypes: { viewScript: ['QDS', 'qds', 'wxs'] } })
+		const tags = getViewScriptTags()
+		expect(tags).toEqual(['wxs', 'dds', 'qds'])
+		expect(new Set(tags).size).toBe(tags.length)
+	})
+
+	// bug：标签会被拼成 Cheerio 选择器（transTagWxs 的 $(tags.join(','))），
+	// 含逗号的项如 'qds,view' 会让选择器变成 wxs,dds,qds,view，把所有 <view> 选中并 remove，
+	// 破坏模板。带选择器元字符的项必须被丢弃。
+	it('viewScript 含选择器元字符（逗号/冒号/点）的项被丢弃', () => {
+		storeInfo(tempDir, { fileTypes: { viewScript: ['qds,view', 'a:b', 'x.y', 'qds'] } })
+		expect(getViewScriptTags()).toEqual(['wxs', 'dds', 'qds'])
+		expect(getViewScriptExts()).toEqual(['.wxs', '.qds'])
+	})
+
+	// bug：标签名必须以字母开头（合法 XML/HTML 标签名），数字开头的项丢弃
+	it('数字开头的 viewScript 标签被丢弃（非法标签名）', () => {
+		storeInfo(tempDir, { fileTypes: { viewScript: ['1qds', 'qds'] } })
+		expect(getViewScriptTags()).toEqual(['wxs', 'dds', 'qds'])
+	})
+
+	// bug：扩展名同样会被拼进剥除正则/查找逻辑，含元字符（内部点、*、逗号）的项必须丢弃
+	it('template/style 含元字符的扩展名被丢弃', () => {
+		storeInfo(tempDir, { fileTypes: { template: ['q.dml', 'qd*ml', 'a,b', 'qdml'], style: ['q:ss', 'qdss'] } })
+		expect(getTemplateExts()).toEqual(['.wxml', '.ddml', '.qdml'])
+		expect(getStyleExts()).toEqual(['.wxss', '.ddss', '.less', '.scss', '.sass', '.qdss'])
+	})
+
+	// bug：自定义项若占用其他角色/逻辑(.js/.ts)/配置(.json)的扩展名，会跨角色串编
+	// （如 template:['js'] 把页面逻辑文件当模板解析）。保留扩展名必须被丢弃。
+	it('占用保留扩展名（其他角色/逻辑/配置）的自定义项被丢弃', () => {
+		storeInfo(tempDir, { fileTypes: {
+			template: ['js', 'ts', 'json', 'wxss', 'qdml'],
+			viewScript: ['js', 'wxml', 'qds'],
+		} })
+		expect(getTemplateExts()).toEqual(['.wxml', '.ddml', '.qdml'])
+		expect(getViewScriptExts()).toEqual(['.wxs', '.qds'])
+	})
+})
+
+describe('custom file types — storeInfo 返回值 compilerOptions', () => {
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'custom-store-'))
+		prepareMinimalProject()
+	})
+
+	afterEach(() => {
+		if (tempDir && fs.existsSync(tempDir)) {
+			fs.rmSync(tempDir, { recursive: true, force: true })
+		}
+	})
+
+	// bug：worker 还原路径靠 resetStoreInfo({...storeInfo()})，若 storeInfo 不返回
+	// compilerOptions，子进程将丢失自定义文件类型配置 → 主/子进程编译结果不一致
+	it('storeInfo 返回值在 pathInfo/configInfo 之外新增 compilerOptions', () => {
+		const result = storeInfo(tempDir, { fileTypes: { template: ['qdml'] } })
+		expect(result).toHaveProperty('pathInfo')
+		expect(result).toHaveProperty('configInfo')
+		expect(result).toHaveProperty('compilerOptions')
+	})
+
+	// bug：resetStoreInfo 不还原 compilerOptions → worker 端 getter 退回默认值
+	it('resetStoreInfo 能还原 compilerOptions（worker 还原路径）', () => {
+		const snapshot = storeInfo(tempDir, { fileTypes: { template: ['qdml'] } })
+
+		// 模拟另一次 storeInfo 把单例覆盖回默认
+		storeInfo(tempDir)
+		expect(getTemplateExts()).not.toContain('.qdml')
+
+		// 模拟 worker：用快照还原
+		resetStoreInfo(snapshot)
+		expect(getTemplateExts()).toContain('.qdml')
+	})
+})
+
+describe('custom file types — 跨构建重置（不泄漏）', () => {
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'custom-reset-'))
+		prepareMinimalProject()
+	})
+
+	afterEach(() => {
+		if (tempDir && fs.existsSync(tempDir)) {
+			fs.rmSync(tempDir, { recursive: true, force: true })
+		}
+	})
+
+	// 关键 bug：env 单例 + build() 反复调用。若 compilerOptions 不在每次 storeInfo
+	// 时按本次 options 重建，上一次注入的 .qdml 会泄漏到下一次无配置的构建。
+	it('上一次注入的自定义扩展名不得泄漏到下一次无 fileTypes 的 storeInfo', () => {
+		storeInfo(tempDir, { fileTypes: { template: ['qdml'] } })
+		expect(getTemplateExts()).toContain('.qdml')
+
+		storeInfo(tempDir)
+		expect(getTemplateExts()).not.toContain('.qdml')
+		expect(getTemplateExts()).toEqual(['.wxml', '.ddml'])
+	})
+
+	// bug：泄漏不仅发生在 template，style/viewScript 三个角色都必须各自按本次重建
+	it('style 与 viewScript 同样不跨构建泄漏', () => {
+		storeInfo(tempDir, { fileTypes: { style: ['qdss'], viewScript: ['qds'] } })
+		expect(getStyleExts()).toContain('.qdss')
+		expect(getViewScriptExts()).toContain('.qds')
+		expect(getViewScriptTags()).toContain('qds')
+
+		storeInfo(tempDir, { fileTypes: { template: ['qdml'] } })
+		// 本次只注入了 template，上次的 style/viewScript 自定义扩展名应消失
+		expect(getStyleExts()).not.toContain('.qdss')
+		expect(getViewScriptExts()).not.toContain('.qds')
+		expect(getViewScriptTags()).not.toContain('qds')
+		// 而本次的 template 自定义扩展名应生效
+		expect(getTemplateExts()).toContain('.qdml')
+	})
+})
+
+/**
+ * 行为/集成层占位。
+ *
+ * 这里需要一个含 .qdml + .qdss + .qds 文件以及内联 <qds module="..."> 标签的最小工程，
+ * 跑完整 compileV/compileSS 并断言其产物与等价 wxml/wxss/wxs 工程一致。
+ * fixture 与编译管线挂接成本较高（涉及多个 core 模块如何消费这四个 getter），
+ * 先以 it.todo 锁定意图，待 env 层契约稳定后再补。
+ */
+describe('custom file types — 行为层（集成）', () => {
+	let originalTargetPath
+
+	beforeEach(() => {
+		originalTargetPath = process.env.TARGET_PATH
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'custom-integration-'))
+	})
+
+	afterEach(() => {
+		if (originalTargetPath) {
+			process.env.TARGET_PATH = originalTargetPath
+		}
+		else {
+			delete process.env.TARGET_PATH
+		}
+		if (tempDir && fs.existsSync(tempDir)) {
+			fs.rmSync(tempDir, { recursive: true, force: true })
+		}
+	})
+
+	/**
+	 * 写出一个最小工程骨架（不含模板/样式文件，由各 case 自己用自定义扩展名补齐）。
+	 *
+	 * 注意：view-compiler 有模块级 compileResCache（按 module.path 缓存），且本文件内
+	 * 测试共享同一模块实例。若多个 case 复用同一页面路径，后跑的会命中前一个 case 的
+	 * 编译缓存，读到串味的产物。因此每个集成 case 用各自唯一的 pagePath 隔离缓存键。
+	 */
+	function prepareSkeleton(pagePath) {
+		writeProjectFile('app.json', JSON.stringify({ pages: [pagePath] }))
+		writeProjectFile('project.config.json', JSON.stringify({ appid: 'custom-int' }))
+		writeProjectFile(`${pagePath}.json`, JSON.stringify({}))
+		writeProjectFile(`${pagePath}.js`, 'Page({})')
+	}
+
+	function setTargetPath() {
+		const outputDir = path.join(tempDir, 'dist')
+		fs.mkdirSync(outputDir, { recursive: true })
+		process.env.TARGET_PATH = outputDir
+		return outputDir
+	}
+
+	// bug：自定义模板扩展名注入后，view-compiler 仍只 glob .wxml → .qdml 工程编不出 view.js
+	it('.qdml 被识别为模板，编译出与 .wxml 等价的 view.js', async () => {
+		const pagePath = 'pages/tpl/index'
+		prepareSkeleton(pagePath)
+		// 页面只提供 .qdml 模板（无 .wxml），含一个可识别的组件引用作为特征串
+		writeProjectFile(`${pagePath}.json`, JSON.stringify({
+			usingComponents: { nav: '/components/nav' },
+		}))
+		writeProjectFile(`${pagePath}.qdml`, '<view><nav /></view>')
+		writeProjectFile('components/nav/index.json', JSON.stringify({ component: true }))
+		writeProjectFile('components/nav/index.qdml', '<view class="nav">nav</view>')
+
+		const outputDir = setTargetPath()
+
+		const { storeInfo: store, getPages } = await import('../src/env.js')
+		store(tempDir, { fileTypes: { template: ['qdml'] } })
+
+		const { compileML } = await import('../src/core/view-compiler.js')
+		await compileML(getPages().mainPages, null, { completedTasks: 0 })
+
+		const outputPath = path.join(outputDir, 'main/pages_tpl_index.js')
+		expect(fs.existsSync(outputPath)).toBe(true)
+
+		const output = fs.readFileSync(outputPath, 'utf-8')
+		// 特征串：模板里引用的组件路径必须出现在产物中，证明 .qdml 被当模板编译了
+		expect(output).toContain('/components/nav')
+	})
+
+	// 对照：同样的 .qdml 工程，若不注入 fileTypes，.qdml 不应被识别为模板
+	// （产物不存在或不含该组件引用），证明上面的成功是自定义文件类型生效而非碰巧。
+	it('对照：不注入 fileTypes 时同样的 .qdml 工程不产出含该内容的 view.js', async () => {
+		const pagePath = 'pages/tplneg/index'
+		prepareSkeleton(pagePath)
+		writeProjectFile(`${pagePath}.json`, JSON.stringify({
+			usingComponents: { nav: '/components/nav' },
+		}))
+		writeProjectFile(`${pagePath}.qdml`, '<view><nav /></view>')
+		writeProjectFile('components/nav/index.json', JSON.stringify({ component: true }))
+		writeProjectFile('components/nav/index.qdml', '<view class="nav">nav</view>')
+
+		const outputDir = setTargetPath()
+
+		const { storeInfo: store, getPages } = await import('../src/env.js')
+		store(tempDir) // 不注入自定义文件类型
+
+		const { compileML } = await import('../src/core/view-compiler.js')
+		await compileML(getPages().mainPages, null, { completedTasks: 0 })
+
+		const outputPath = path.join(outputDir, 'main/pages_tplneg_index.js')
+		const exists = fs.existsSync(outputPath)
+		if (exists) {
+			const output = fs.readFileSync(outputPath, 'utf-8')
+			// 没注入配置时不应把 .qdml 当模板编进去
+			expect(output).not.toContain('class="nav"')
+		}
+		else {
+			expect(exists).toBe(false)
+		}
+	})
+
+	// bug：自定义样式扩展名注入后，style-compiler 仍只 glob .wxss → .qdss 规则丢失
+	it('.qdss 被识别为样式，编译出与 .wxss 等价的 css', async () => {
+		const pagePath = 'pages/sty/index'
+		prepareSkeleton(pagePath)
+		// 页面提供 .qdml 模板 + .qdss 样式（含一条简单到不会被优化掉的规则）
+		writeProjectFile(`${pagePath}.qdml`, '<view class="brand">home</view>')
+		writeProjectFile(`${pagePath}.qdss`, '.brand { color: red; }')
+
+		const outputDir = setTargetPath()
+
+		const { storeInfo: store, getPages } = await import('../src/env.js')
+		store(tempDir, { fileTypes: { template: ['qdml'], style: ['qdss'] } })
+
+		const { compileSS } = await import('../src/core/style-compiler.js')
+		await compileSS(getPages().mainPages, null, { completedTasks: 0 })
+
+		const outputPath = path.join(outputDir, 'main/pages_sty_index.css')
+		expect(fs.existsSync(outputPath)).toBe(true)
+
+		const output = fs.readFileSync(outputPath, 'utf-8')
+		// 特征：选择器与声明都必须出现（允许压缩去空格）
+		expect(output).toContain('.brand')
+		expect(output).toMatch(/color\s*:\s*red/)
+	})
+
+	// bug：viewScript 注入只更新扩展名/标签但 view-compiler 未消费 → .qds 文件 &
+	// 内联 <qds module> 标签均不被当 WXS 类脚本编译进产物
+	it('.qds 文件与内联 <qds> 标签被当作 WXS 类脚本编译', async () => {
+		const pagePath = 'pages/vs/index'
+		prepareSkeleton(pagePath)
+		// 内联 <qds module="m1"> 导出函数；同时 src 引用外部 .qds 文件
+		writeProjectFile(`${pagePath}.qdml`, `
+<qds module="m1">
+	function inlineFn(text) {
+		return text + ' from inline qds'
+	}
+	module.exports = { inlineFn: inlineFn }
+</qds>
+<qds module="m2" src="./util.qds" />
+<view>
+	<text>{{m1.inlineFn('Hi')}}</text>
+	<text>{{m2.srcFn('Hi')}}</text>
+</view>
+		`)
+		writeProjectFile('pages/vs/util.qds', `
+function srcFn(text) {
+	return text + ' from src qds'
+}
+module.exports = { srcFn: srcFn }
+		`)
+
+		const outputDir = setTargetPath()
+
+		const { storeInfo: store, getPages } = await import('../src/env.js')
+		store(tempDir, { fileTypes: { template: ['qdml'], viewScript: ['qds'] } })
+
+		const { compileML } = await import('../src/core/view-compiler.js')
+		await compileML(getPages().mainPages, null, { completedTasks: 0 })
+
+		const outputPath = path.join(outputDir, 'main/pages_vs_index.js')
+		expect(fs.existsSync(outputPath)).toBe(true)
+
+		const output = fs.readFileSync(outputPath, 'utf-8')
+		// 内联 <qds module="m1"> → 以模块名 m1 注册（与 <wxs module> 等价形态）
+		expect(output).toContain('modDefine("m1"')
+		expect(output).toContain('inlineFn')
+		expect(output).toContain('from inline qds')
+		// src 引用的 .qds 文件 → 以文件路径派生 id 注册（与 <wxs src> 等价形态）。
+		// 与内联模块不同，src 模块用 util.qds 的路径名 pages_vs_util，而非标签上的 m2。
+		expect(output).toContain('modDefine("pages_vs_util"')
+		expect(output).toContain('srcFn')
+		expect(output).toContain('from src qds')
+		// 页面 render 通过依赖注入引用这两个 qds 模块（证明 .qds + <qds> 被当 WXS 类脚本编进来了）
+		expect(output).toContain('"m1"')
+		expect(output).toContain('"pages_vs_util"')
+		// WXS 类脚本特征：exports（压缩后可能是 t.exports / module.exports / n.exports 等）
+		expect(output).toMatch(/\w\.exports/)
+	})
+
+	// brand 前缀指令：编译器按指令后缀(:if/:for/:key…)匹配、与前缀无关，所以 .qdml 里写
+	// qd:if / qd:for 会和 wx:if / wx:for 一样编成 v-if / v-for。守住「不得硬编码 wx: 前缀」。
+	it('.qdml 里的 qd: 前缀指令（if/else/for/for-item/for-index/key）按 v-if/v-for 编译', async () => {
+		const pagePath = 'pages/dir/index'
+		prepareSkeleton(pagePath)
+		writeProjectFile(`${pagePath}.js`, 'Page({ data: { show: true, list: [{ id: 1, name: "a" }] } })')
+		writeProjectFile(`${pagePath}.qdml`, [
+			'<view qd:if="{{ show }}">on</view>',
+			'<view qd:else>off</view>',
+			'<view qd:for="{{ list }}" qd:for-item="it" qd:for-index="idx" qd:key="id">{{ idx }}:{{ it.name }}</view>',
+		].join('\n'))
+
+		const outputDir = setTargetPath()
+
+		const { storeInfo: store, getPages } = await import('../src/env.js')
+		store(tempDir, { fileTypes: { template: ['qdml'] } })
+
+		const { compileML } = await import('../src/core/view-compiler.js')
+		await compileML(getPages().mainPages, null, { completedTasks: 0 })
+
+		const output = fs.readFileSync(path.join(outputDir, 'main/pages_dir_index.js'), 'utf-8')
+		// qd:if/qd:else → 条件分支：以 show 为条件的三元块
+		expect(output).toContain('show')
+		expect(output).toMatch(/\?\(_openBlock/)
+		// qd:for → v-for 经 _renderList 展开 list
+		expect(output).toContain('_renderList')
+		expect(output).toContain('list')
+		// qd:key → 列表项 key 绑定
+		expect(output).toMatch(/key:/)
+	})
+})

--- a/fe/packages/compiler/__tests__/npm-view-script-custom-loading.spec.js
+++ b/fe/packages/compiler/__tests__/npm-view-script-custom-loading.spec.js
@@ -1,0 +1,69 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { storeInfo } from '../src/env.js'
+import { initWxsFilePathMap, loadWxsModule } from '../src/core/view-compiler.js'
+
+/**
+ * 回归：loadWxsModule 通过文件系统兜底加载「依赖发现」到的 npm 视图脚本时，
+ * 旧实现用硬编码的 '_wxs_' 路径片段 + 'miniprogram_npm__' 双下划线做门槛——只对
+ * scoped 包(@scope→//→__)且放在 wxs/ 目录的 .wxs 生效。自定义扩展名(.qds)的模块 id
+ * 形如 miniprogram_npm_pkg_qds_util（单下划线、无 _wxs_）会被一律拒绝 → 漏编译。
+ * 修复后改用 wxsFilePathMap（扫描权威来源）判定 + 定位，与扩展名/命名无关。
+ */
+describe('npm 视图脚本自定义类型：loadWxsModule 不依赖 _wxs_ 片段', () => {
+  let tempDir
+
+  function write(rel, content) {
+    const full = path.join(tempDir, rel)
+    fs.mkdirSync(path.dirname(full), { recursive: true })
+    fs.writeFileSync(full, content)
+  }
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'npm-vs-custom-'))
+    // 最小工程（storeInfo 需要 app.json / project.config.json）
+    write('app.json', JSON.stringify({ pages: ['pages/home/index'] }))
+    write('project.config.json', JSON.stringify({ appid: 'vs-custom' }))
+    write('pages/home/index.json', JSON.stringify({}))
+    write('pages/home/index.wxml', '<view>home</view>')
+    write('pages/home/index.js', 'Page({})')
+    // 非 scoped 包 + qds/ 目录 + .qds 扩展名 → id = miniprogram_npm_pkg_qds_util（无 _wxs_）
+    write('miniprogram_npm/pkg/qds/util.qds', 'module.exports = { brand: function () { return 42 } }')
+    // 非 wxs/ 目录的 .wxs → id = miniprogram_npm_pkg_helper（旧实现也会漏，顺带证明修复）
+    write('miniprogram_npm/pkg/helper.wxs', 'module.exports = { help: function () { return 1 } }')
+  })
+
+  afterEach(() => {
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('加载自定义扩展名(.qds)的 npm 视图脚本依赖', () => {
+    storeInfo(tempDir, { fileTypes: { viewScript: ['qds'] } })
+    initWxsFilePathMap(tempDir)
+
+    const loaded = loadWxsModule('miniprogram_npm_pkg_qds_util', tempDir, [])
+    expect(loaded).toBeTruthy()
+    expect(loaded.path).toBe('miniprogram_npm_pkg_qds_util')
+    expect(loaded.code).toContain('brand')
+  })
+
+  it('加载不在 wxs/ 目录、模块 id 不含 _wxs_ 的 .wxs 依赖（潜伏 bug 修复）', () => {
+    storeInfo(tempDir)
+    initWxsFilePathMap(tempDir)
+
+    const loaded = loadWxsModule('miniprogram_npm_pkg_helper', tempDir, [])
+    expect(loaded).toBeTruthy()
+    expect(loaded.code).toContain('help')
+  })
+
+  it('未扫描到的模块 id 返回 null', () => {
+    storeInfo(tempDir, { fileTypes: { viewScript: ['qds'] } })
+    initWxsFilePathMap(tempDir)
+
+    expect(loadWxsModule('miniprogram_npm_pkg_does_not_exist', tempDir, [])).toBeNull()
+  })
+})

--- a/fe/packages/compiler/src/common/compatibility.js
+++ b/fe/packages/compiler/src/common/compatibility.js
@@ -1,4 +1,5 @@
 import { Parser } from 'htmlparser2'
+import { getViewScriptTags } from '../env.js'
 import { supportedBuiltinComponents, supportedWxApis } from './compatibility-reference.js'
 
 let cachedReference = null
@@ -125,7 +126,9 @@ function warnUnsupportedWxApi(apiName, filePath, line) {
 
 function warnUnsupportedComponent(tagName, filePath, line) {
 	const { supportedBuiltinComponents } = loadReference()
-	if (!tagName || supportedBuiltinComponents.has(tagName)) {
+	// 视图脚本标签（wxs、dds 及自定义标签）不是组件，需动态豁免。
+	// 兼容性清单仅包含 wxs，因此还需在此放行 dds 和自定义标签，避免误报。
+	if (!tagName || supportedBuiltinComponents.has(tagName) || getViewScriptTags().includes(tagName)) {
 		return
 	}
 

--- a/fe/packages/compiler/src/common/npm-builder.js
+++ b/fe/packages/compiler/src/common/npm-builder.js
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { getStyleExts, getTemplateExts, getViewScriptExts } from '../env.js'
 
 /**
  * npm 构建工具
@@ -145,7 +146,9 @@ class NpmBuilder {
 	 * @returns {boolean} 是否为小程序文件
 	 */
 	isMiniprogramFile(filename) {
-		const miniprogramExts = ['.js', '.json', '.wxml', '.wxss', '.wxs', '.ts', '.less', '.scss', '.styl']
+		// 根据自定义文件类型配置组合扩展名，覆盖内置 wx/dd 类型、样式预处理器和自定义扩展名。
+		// getStyleExts 已包含 .less/.scss/.sass；NpmBuilder 在主线程中构造，可直接读取 env getter。
+		const miniprogramExts = ['.js', '.json', '.ts', ...getTemplateExts(), ...getStyleExts(), ...getViewScriptExts()]
 		const ext = path.extname(filename).toLowerCase()
 		
 		return miniprogramExts.includes(ext) || 

--- a/fe/packages/compiler/src/core/style-compiler.js
+++ b/fe/packages/compiler/src/core/style-compiler.js
@@ -9,9 +9,8 @@ import postcss from 'postcss'
 import selectorParser from 'postcss-selector-parser'
 import * as sass from 'sass'
 import { collectAssets, tagWhiteList, transformRpx } from '../common/utils.js'
-import { getAppId, getComponent, getContentByPath, getTargetPath, getWorkPath, resetStoreInfo } from '../env.js'
+import { getAppId, getComponent, getContentByPath, getStyleExts, getTargetPath, getWorkPath, resetStoreInfo } from '../env.js'
 
-const fileType = ['.wxss', '.ddss', '.less', '.scss', '.sass']
 const compileRes = new Map()
 
 if (!isMainThread) {
@@ -273,7 +272,7 @@ function getAbsolutePath(modulePath) {
 	const workPath = getWorkPath()
 	const src = modulePath.startsWith('/') ? modulePath : `/${modulePath}`
 
-	for (const ssType of fileType) {
+	for (const ssType of getStyleExts()) {
 		const ssFullPath = `${workPath}${src}${ssType}`
 		if (fs.existsSync(ssFullPath)) {
 			return ssFullPath

--- a/fe/packages/compiler/src/core/view-compiler.js
+++ b/fe/packages/compiler/src/core/view-compiler.js
@@ -10,10 +10,23 @@ import { transform } from 'esbuild'
 import * as htmlparser2 from 'htmlparser2'
 import { checkTemplateCompatibility } from '../common/compatibility.js'
 import { collectAssets, getAbsolutePath, tagWhiteList, transformRpx } from '../common/utils.js'
-import { getAppId, getComponent, getContentByPath, getTargetPath, getWorkPath, resetStoreInfo } from '../env.js'
+import { getAppId, getComponent, getContentByPath, getTargetPath, getTemplateExts, getViewScriptExts, getViewScriptTags, getWorkPath, resetStoreInfo } from '../env.js'
 import { parseBindings } from '../common/expression-parser.js'
 
-const fileType = ['.wxml', '.ddml']
+/**
+ * 根据扩展名列表生成匹配尾部扩展名的正则，如 ['.wxs', '.qds'] -> /(\.wxs|\.qds)$/
+ */
+function buildExtStripRegex(exts) {
+	const alt = exts.map(e => e.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')
+	return new RegExp(`(${alt})$`)
+}
+
+/**
+ * 移除视图脚本文件路径末尾的扩展名，支持 .wxs 和自定义扩展名
+ */
+function stripViewScriptExt(p) {
+	return p.replace(buildExtStripRegex(getViewScriptExts()), '')
+}
 
 /**
  * 解析 JavaScript 代码
@@ -308,9 +321,9 @@ function scanWxsFiles(dir, workPath) {
 			if (stat.isDirectory()) {
 				// 递归扫描子目录
 				scanWxsFiles(fullPath, workPath)
-			} else if (stat.isFile() && item.endsWith('.wxs')) {
+			} else if (stat.isFile() && getViewScriptExts().some(ext => item.endsWith(ext))) {
 				// 处理 wxs 文件
-				const relativePath = fullPath.replace(workPath, '').replace(/\.wxs$/, '')
+				const relativePath = stripViewScriptExt(fullPath.replace(workPath, ''))
 				const moduleName = relativePath.replace(/[\/\\@\-]/g, '_').replace(/^_/, '')
 
 				// 建立模块名到文件路径的映射
@@ -651,8 +664,8 @@ function processWxsContent(wxsContent, wxsFilePath, scriptModule, workPath, file
 							const currentWxsDir = path.dirname(wxsFilePath)
 							resolvedWxsPath = path.resolve(currentWxsDir, requirePath)
 
-							// 转换为相对于工作目录的路径，并移除 .wxs 扩展名
-							const relativePath = resolvedWxsPath.replace(workPath, '').replace(/\.wxs$/, '')
+							// 转换为相对于工作目录的路径，并移除视图脚本扩展名
+							const relativePath = stripViewScriptExt(resolvedWxsPath.replace(workPath, ''))
 
 							// 生成唯一的模块名（移除特殊字符）
 							const moduleName = relativePath.replace(/[\/\\@\-]/g, '_').replace(/^_/, '')
@@ -671,7 +684,7 @@ function processWxsContent(wxsContent, wxsFilePath, scriptModule, workPath, file
 							// 对于普通组件，使用原有逻辑
 							const currentWxsDir = path.dirname(wxsFilePath)
 							resolvedWxsPath = path.resolve(currentWxsDir, requirePath)
-							const relativePath = resolvedWxsPath.replace(workPath, '').replace(/\.wxs$/, '')
+							const relativePath = stripViewScriptExt(resolvedWxsPath.replace(workPath, ''))
 							const depModuleName = relativePath.replace(/[\/\\@\-]/g, '_').replace(/^_/, '')
 
 							// 递归处理依赖
@@ -999,7 +1012,7 @@ function toCompileTemplate(isComponent, path, components, componentPlaceholder, 
 		if (src) {
 			const includeFullPath = getAbsolutePath(workPath, path, src)
 			// 计算被包含文件的路径（去掉扩展名），用于 wxs 路径解析
-			let includePath = includeFullPath.replace(workPath, '').replace(/\.(wxml|ddml)$/, '')
+			let includePath = includeFullPath.replace(workPath, '').replace(buildExtStripRegex(getTemplateExts()), '')
 			const includeDiagnosticSource = includeFullPath.startsWith(workPath)
 				? includeFullPath.slice(workPath.length)
 				: includePath
@@ -1038,8 +1051,7 @@ function toCompileTemplate(isComponent, path, components, componentPlaceholder, 
 				processIncludedFileWxsDependencies(includeContent, includePath, scriptModule, components, processedPaths)
 
 				$includeContent('template').remove()
-				$includeContent('wxs').remove()
-				$includeContent('dds').remove()
+				$includeContent(getViewScriptTags().join(',')).remove()
 
 				// 处理条件属性并替换
 				const processedContent = processIncludeConditionalAttrs($, elem, $includeContent.html())
@@ -1069,7 +1081,7 @@ function toCompileTemplate(isComponent, path, components, componentPlaceholder, 
 		const src = $(elem).attr('src')
 		if (src) {
 			const importFullPath = getAbsolutePath(workPath, path, src)
-			let importPath = importFullPath.replace(workPath, '').replace(/\.(wxml|ddml)$/, '')
+			let importPath = importFullPath.replace(workPath, '').replace(buildExtStripRegex(getTemplateExts()), '')
 			const importDiagnosticSource = importFullPath.startsWith(workPath)
 				? importFullPath.slice(workPath.length)
 				: importPath
@@ -1133,8 +1145,7 @@ function transTagTemplate($, templateModule, path, components, componentPlacehol
 		// 转化模板内代码
 		templateContent.find('import').remove()
 		templateContent.find('include').remove()
-		templateContent.find('wxs').remove()
-		templateContent.find('dds').remove()
+		templateContent.find(getViewScriptTags().join(',')).remove()
 		transAsses($, templateContent.find('image'), path)
 		const res = []
 		transHtmlTag(templateContent.html(), res, components, componentPlaceholder)
@@ -1579,7 +1590,7 @@ function parseKeyExpression(exp, itemName = 'item', indexName = 'index') {
  */
 function getViewPath(workPath, src) {
 	const aSrc = src.startsWith('/') ? src : `/${src}`
-	for (const mlType of fileType) {
+	for (const mlType of getTemplateExts()) {
 		const mlFullPath = `${workPath}${aSrc}${mlType}`
 		if (fs.existsSync(mlFullPath)) {
 			return mlFullPath
@@ -1755,10 +1766,8 @@ function parseTemplateDataExp(exp) {
 }
 
 function transTagWxs($, scriptModule, filePath) {
-	let wxsNodes = $('wxs')
-	if (wxsNodes.length === 0) {
-		wxsNodes = $('dds')
-	}
+	// 同时处理所有视图脚本标签（wxs、dds 及自定义标签），避免同一文件混用多种标签时漏编译。
+	const wxsNodes = $(getViewScriptTags().join(','))
 
 	wxsNodes.each((_, elem) => {
 		const smName = $(elem).attr('module')
@@ -1792,7 +1801,7 @@ function transTagWxs($, scriptModule, filePath) {
 
 				if (wxsFilePath) {
 					// 为外部 wxs 文件生成唯一的模块名和缓存键
-					const relativePath = wxsFilePath.replace(workPath, '').replace(/\.wxs$/, '')
+					const relativePath = stripViewScriptExt(wxsFilePath.replace(workPath, ''))
 					uniqueModuleName = relativePath.replace(/[\/\\@\-]/g, '_').replace(/^_/, '')
 					cacheKey = wxsFilePath // 使用文件路径作为缓存键确保唯一性
 				}
@@ -1901,16 +1910,12 @@ function collectAllWxsModules(scriptRes, collectedPaths = new Set(), scriptModul
  * @returns {Object|null} 加载的模块对象或 null
  */
 function loadWxsModule(modulePath, workPath, scriptModule) {
-	// 如果模块路径不是 wxs 模块特征，直接返回 null
-	if (!modulePath.startsWith('miniprogram_npm__') || !modulePath.includes('_wxs_')) {
-		return null
-	}
-
-	// 从预先建立的路径映射中查找文件路径
+	// wxsFilePathMap 记录 miniprogram_npm 下使用任意已配置扩展名的视图脚本文件，
+	// 用于判断并定位模块。不能依赖 '_wxs_' 路径片段，否则会漏掉自定义扩展名
+	// （如 .qds），以及路径中不含 wxs 目录的 .wxs 文件。
 	const wxsFilePath = wxsFilePathMap.get(modulePath)
 
 	if (!wxsFilePath) {
-		console.warn(`[view] 无法找到 wxs 模块文件: ${modulePath}`)
 		return null
 	}
 
@@ -2030,6 +2035,8 @@ export {
 	compileML,
 	generateVModelTemplate,
 	generateSlotDirective,
+	initWxsFilePathMap,
+	loadWxsModule,
 	parseBraceExp,
 	parseClassRules,
 	parseKeyExpression,

--- a/fe/packages/compiler/src/env.js
+++ b/fe/packages/compiler/src/env.js
@@ -10,29 +10,141 @@ let pathInfo = {}
 let configInfo = {}
 let npmResolver = null
 
+// 小程序自定义文件类型：可扩展的文件扩展名和内联标签。
+// 始终保留内置 wx/dd 类型；调用方通过 build() 或 storeInfo() 的 options.fileTypes 追加自定义项。
+const DEFAULT_TEMPLATE_EXTS = ['.wxml', '.ddml']
+const DEFAULT_STYLE_EXTS = ['.wxss', '.ddss', '.less', '.scss', '.sass']
+const DEFAULT_VIEW_SCRIPT_EXTS = ['.wxs']
+const DEFAULT_VIEW_SCRIPT_TAGS = ['wxs', 'dds']
+
+// 保留扩展名：所有内置类型 + 逻辑(.js/.ts) + 配置(.json)。自定义项不得占用，
+// 否则会跨角色串编（如 template:['js'] 会把页面逻辑文件当成模板解析）。
+const RESERVED_EXTS = new Set([
+	...DEFAULT_TEMPLATE_EXTS,
+	...DEFAULT_STYLE_EXTS,
+	...DEFAULT_VIEW_SCRIPT_EXTS,
+	'.js',
+	'.ts',
+	'.json',
+])
+
+// 编译选项单例。env 会跨多次 build() 持久化；每次 storeInfo() 根据当前 options 重建，避免自定义文件类型串用。
+let compilerOptions = normalizeFileTypes()
+
+/**
+ * 将单项规范化为扩展名：去除首尾空白、转小写并补一个前导点。
+ * 仅接受字母、数字、连字符和下划线；空字符串、路径分隔符或其他元字符
+ * 均返回 null，由调用方丢弃。扩展名会用于生成尾部匹配正则和查找文件，
+ * 放行元字符可能导致误匹配。
+ */
+function normalizeExt(raw) {
+	if (typeof raw !== 'string') {
+		return null
+	}
+	const v = raw.trim().toLowerCase().replace(/^\.+/, '')
+	if (!/^[a-z0-9_-]+$/.test(v)) {
+		return null
+	}
+	return `.${v}`
+}
+
+/**
+ * 将单项规范化为内联标签名：去除首尾空白、转小写并移除前导点。
+ * 标签名会用于拼接 Cheerio 选择器（如 transTagWxs），因此必须以字母开头，
+ * 且只能包含字母、数字、连字符和下划线。拒绝选择器元字符，避免 'qds,view'
+ * 误选并删除 <view>，破坏编译产物。
+ */
+function normalizeTag(raw) {
+	if (typeof raw !== 'string') {
+		return null
+	}
+	const v = raw.trim().toLowerCase().replace(/^\.+/, '')
+	if (!/^[a-z][a-z0-9_-]*$/.test(v)) {
+		return null
+	}
+	return v
+}
+
+/**
+ * 合并并去重内置项和自定义项；内置项在前，顺序即同名文件的查找优先级。
+ * 传入 reserved 时，落在其中的自定义项被丢弃（防止占用其他角色/逻辑/配置的扩展名）。
+ */
+function mergeUnique(builtins, custom, normalizer, reserved) {
+	const out = [...builtins]
+	const seen = new Set(builtins)
+	if (Array.isArray(custom)) {
+		for (const raw of custom) {
+			const n = normalizer(raw)
+			if (n && !seen.has(n) && !reserved?.has(n)) {
+				seen.add(n)
+				out.push(n)
+			}
+		}
+	}
+	return out
+}
+
+/**
+ * 根据 options.fileTypes 生成本次构建使用的自定义扩展名和标签。
+ * viewScript 同时用于生成文件扩展名和内联标签。
+ */
+function normalizeFileTypes(fileTypes = {}) {
+	const ft = fileTypes || {}
+	return {
+		templateExts: mergeUnique(DEFAULT_TEMPLATE_EXTS, ft.template, normalizeExt, RESERVED_EXTS),
+		styleExts: mergeUnique(DEFAULT_STYLE_EXTS, ft.style, normalizeExt, RESERVED_EXTS),
+		viewScriptExts: mergeUnique(DEFAULT_VIEW_SCRIPT_EXTS, ft.viewScript, normalizeExt, RESERVED_EXTS),
+		viewScriptTags: mergeUnique(DEFAULT_VIEW_SCRIPT_TAGS, ft.viewScript, normalizeTag),
+	}
+}
+
 /**
  * 持久化编译过程的上下文
+ * @param {string} workPath 编译工作目录
+ * @param {{ fileTypes?: { template?: string[], style?: string[], viewScript?: string[] } }} [options] 构建选项
  */
-function storeInfo(workPath) {
+function storeInfo(workPath, options = {}) {
 	storePathInfo(workPath)
 	storeProjectConfig()
 	storeAppConfig()
 	storePageConfig()
 
+	// 根据当前 options 重建，避免上一次 build() 注入的自定义文件类型影响本次构建。
+	compilerOptions = normalizeFileTypes(options.fileTypes)
+
 	return {
 		pathInfo,
 		configInfo,
+		compilerOptions,
 	}
 }
 
 function resetStoreInfo(opts) {
 	pathInfo = opts.pathInfo
 	configInfo = opts.configInfo
-	
+	// Worker 恢复上下文时使用主线程生成的自定义文件类型配置，缺省时回退到内置配置。
+	compilerOptions = opts.compilerOptions || normalizeFileTypes()
+
 	// 重新初始化 npm 解析器
 	if (pathInfo.workPath) {
 		npmResolver = new NpmResolver(pathInfo.workPath)
 	}
+}
+
+function getTemplateExts() {
+	return compilerOptions.templateExts
+}
+
+function getStyleExts() {
+	return compilerOptions.styleExts
+}
+
+function getViewScriptExts() {
+	return compilerOptions.viewScriptExts
+}
+
+function getViewScriptTags() {
+	return compilerOptions.viewScriptTags
 }
 
 function storePathInfo(workPath) {
@@ -381,7 +493,11 @@ export {
 	getPageConfigInfo,
 	getPages,
 	getProjectConfig,
+	getStyleExts,
 	getTargetPath,
+	getTemplateExts,
+	getViewScriptExts,
+	getViewScriptTags,
 	getWorkPath,
 	resetStoreInfo,
 	resolveAppAlias,

--- a/fe/packages/compiler/src/index.js
+++ b/fe/packages/compiler/src/index.js
@@ -15,10 +15,15 @@ let isPrinted = false
  * 构建命令入口
  * @param {string} targetPath 编译产物目标路径
  * @param {string} workPath 编译工作目录
- * @param {boolean} useAppIdDir 产物根目录是否包含appId
+ * @param {boolean} useAppIdDir 产物根目录是否包含 appId
+ * @param {object} [options] 构建选项
+ * @param {boolean} [options.sourcemap] 是否生成 sourcemap
+ * @param {{ template?: string[], style?: string[], viewScript?: string[] }} [options.fileTypes]
+ *   自定义文件类型，在内置 wx/dd 类型基础上追加；template 为模板扩展名，style 为样式扩展名，
+ *   viewScript 为视图脚本扩展名和内联标签名
  */
 export default async function build(targetPath, workPath, useAppIdDir = true, options = {}) {
-	const { sourcemap = false } = options
+	const { sourcemap = false, fileTypes } = options
 	if (!isPrinted) {
 		artCode()
 		isPrinted = true
@@ -33,7 +38,7 @@ export default async function build(targetPath, workPath, useAppIdDir = true, op
 							{
 								title: '收集配置信息',
 								task: (ctx) => {
-									ctx.storeInfo = storeInfo(workPath)
+									ctx.storeInfo = storeInfo(workPath, { fileTypes })
 								},
 							},
 							{

--- a/fe/packages/components/__tests__/button-style-specificity.spec.js
+++ b/fe/packages/components/__tests__/button-style-specificity.spec.js
@@ -57,7 +57,7 @@ describe('Button built-in style specificity', () => {
 	})
 
 	it('exposes class modifiers for styled button states', () => {
-		expect(template).toContain('`dd-button--${type}`')
+		expect(template).toContain(`\`dd-button--\${type}\``)
 		expect(template).toContain("size === 'mini' && 'dd-button--mini'")
 		expect(template).toContain("plainParsed && 'dd-button--plain'")
 		expect(template).toContain("disabledParsed && 'dd-button--disabled'")


### PR DESCRIPTION
## 做了什么

给 `build()` 增加 `options.fileTypes`，允许在内置 `wx*`(`.wxml/.wxss/.wxs`)、`dd*`(`.ddml/.ddss`) 之上**追加自定义文件扩展名**，使其等价编译。通用能力，无品牌耦合。

```js
build(target, work, useAppIdDir, {
  fileTypes: {
    template:   ['xxml'],  // → view.js
    style:      ['xxss'],  // → style.css
    viewScript: ['xxs'],   // .xxs 文件 + 内联 <xxs module> 标签
  },
})
```

- 自定义扩展名自动归一化（补点/小写/去重，仅允许 `[a-z0-9_-]`，不得占用内置或 `.js/.ts/.json`）。
- **完全向后兼容**：不传 `fileTypes` 行为不变；内置 `wx/dd` 永远保留、仅追加。
- 指令（`:if/:for/:key` 等）按后缀匹配，自定义前缀（如 `xx:if`）也能正常编译。
- CLI 暂不开放对应 flag，本次仅扩编程 API。

## 顺带修复（与本改动共用 getter，故一并提交）

- `transTagWxs` 原「无 `<wxs>` 才回退 `<dds>`」会漏编同时含两种标签的文件。
- npm 文件白名单漏 `.ddml/.ddss/.sass`、且含编译器不支持的 `.styl`。
- `loadWxsModule` 旧的 `_wxs_` 路径片段判定只对 scoped 包放在 `wxs/` 目录的 `.wxs` 生效，改用 `wxsFilePathMap` 定位。

## 测试

新增 `custom-file-types.spec` + `npm-view-script-custom-loading.spec`；全量 `vitest` **260 passed**，oxlint 干净。
