### PR TITLE
feat(compiler,render): derive CSS scope id from module path and injec…

### DIFF
--- a/fe/packages/compiler/__tests__/scope-id.spec.js
+++ b/fe/packages/compiler/__tests__/scope-id.spec.js
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { uuid } from '../src/common/utils.js'
+
+// The per-module CSS scope id (`data-v-<id>`) is derived from the module path,
+// not a random uuid. Determinism is load-bearing: the view stage, the style
+// stage, and the render runtime each compute the scope independently, so a
+// random id diverges across worker realms and breaks WXSS; a path hash keeps
+// all three in lock-step and makes compiled output byte-stable / cacheable.
+describe('uuid: deterministic per-path CSS scope id', () => {
+  it('returns the same id for the same path across calls', () => {
+    expect(uuid('pages/index/index')).toBe(uuid('pages/index/index'))
+    expect(uuid('components/foo/foo')).toBe(uuid('components/foo/foo'))
+  })
+
+  it('is a stable hash, not random — pinned so the algorithm cannot drift silently', () => {
+    expect(uuid('pages/index/index')).toBe('1ylz47sm9ljrt')
+    expect(uuid('components/foo/foo')).toBe('1hdsyubayl3kv')
+  })
+
+  it('maps distinct paths to distinct ids', () => {
+    expect(uuid('a')).not.toBe(uuid('b'))
+    expect(uuid('pages/home/home')).not.toBe(uuid('pages/cart/cart'))
+  })
+
+  // Near-identical component paths (same length, differ by a few chars) are the
+  // common case in mini-programs and exactly where a 32-bit crc32 collides —
+  // these two share crc32 `9ys0y6`. A collision means two components share a
+  // scope and cross-contaminate styles, so the hash must be wide enough to keep
+  // them distinct; this pins that guarantee against a regression to a narrow hash.
+  it('keeps near-identical component paths distinct (crc32 collided here)', () => {
+    expect(uuid('/components/c16wtkpz/index')).not.toBe(
+      uuid('/components/c1v8pxjl/index'),
+    )
+  })
+
+  it('produces a base36 token usable verbatim in `data-v-<id>`', () => {
+    const id = uuid('pages/detail/detail')
+    expect(id).toMatch(/^[0-9a-z]+$/)
+    expect(id.length).toBeGreaterThan(0)
+  })
+})

--- a/fe/packages/compiler/src/common/utils.js
+++ b/fe/packages/compiler/src/common/utils.js
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto'
 import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
@@ -67,7 +68,7 @@ function collectAssets(workPath, pagePath, src, targetPath, appId) {
 		// 复制将文件夹下所有同类型的资源文件并加上前缀
 		const ext = `.${src.split('.').pop()}`
 		const dirPath = absolutePath.split(path.sep).slice(0, -1).join('/')
-		const prefix = uuid()
+		const prefix = uuid(dirPath)
 
 		const targetStatic = `${targetPath}/main/static`
 		if (!fs.existsSync(targetStatic)) {
@@ -140,8 +141,13 @@ function transformRpx(styleText) {
 	})
 }
 
-function uuid() {
-	return Math.random().toString(36).slice(2, 7)
+// Deterministic per-path id: the first 64 bits of sha256(path) as a base36
+// token. Determinism is load-bearing — the view/style/render stages each hash
+// the path independently in separate worker realms, so a random id would
+// diverge and break WXSS scoping. 64 bits keeps near-identical component paths
+// (the mini-program norm) collision-free where a 32-bit hash would clash.
+function uuid(str) {
+	return crypto.createHash('sha256').update(str).digest().readBigUInt64BE(0).toString(36)
 }
 
 const tagWhiteList = [

--- a/fe/packages/compiler/src/env.js
+++ b/fe/packages/compiler/src/env.js
@@ -338,7 +338,7 @@ function storeComponentConfig(pageJsonContent, pageFilePath) {
 		}, {})
 
 		configInfo.componentInfo[moduleId] = {
-			id: uuid(),
+			id: uuid(moduleId),
 			path: moduleId,
 			component: isComponent,
 			usingComponents: cComponents,
@@ -451,7 +451,7 @@ function getPages() {
 		const mergedComponents = { ...globalComponents, ...pageComponents }
 		
 		return {
-			id: uuid(),
+			id: uuid(path),
 			path,
 			usingComponents: mergedComponents,
 		}
@@ -470,7 +470,7 @@ function getPages() {
 				const mergedComponents = { ...globalComponents, ...pageComponents }
 				
 				return {
-					id: uuid(),
+					id: uuid(fullPath),
 					path: fullPath,
 					usingComponents: mergedComponents,
 				}

--- a/fe/packages/compiler/vite.config.mjs
+++ b/fe/packages/compiler/vite.config.mjs
@@ -27,6 +27,7 @@ export default defineConfig({
 		rollupOptions: {
 			external: [
 				'node:os',
+				'node:crypto',
 				'node:fs',
 				'node:path',
 				'node:url',

--- a/fe/packages/render/src/core/runtime.js
+++ b/fe/packages/render/src/core/runtime.js
@@ -242,6 +242,7 @@ class Runtime {
 				},
 				components: {
 					[rootCom]: {
+						name: path,
 						__scopeId: sId,
 						async setup(_props, { expose }) {
 							expose()
@@ -406,6 +407,7 @@ class Runtime {
 
 			// setup -> beforeCreate -> beforeMount
 			components[`dd-${componentName}`] = {
+				name: componentPath,
 				__scopeId: sId,
 				components: subComponents,
 				props: module.props,


### PR DESCRIPTION
使用 crc32(path) 取代 scopeId 的 uuid，用来保证 css scope 生成稳定的 id，从而后续可以用于样式热更新。

另外用户的小程序组件编译为 Vue 组件时，将 path 填入 Vue 组件的 name 字段，方便开发者工具实现对 Vue 组件名称的映射。

<img width="419" height="191" alt="image" src="https://github.com/user-attachments/assets/7835eece-188b-463c-b49f-0d76d268abc5" />
