### PR TITLE
feat: 新增微信同款"返回首页"导航按钮

### DIFF
--- a/android/dimina/src/main/kotlin/com/didi/dimina/api/route/RouteApi.kt
+++ b/android/dimina/src/main/kotlin/com/didi/dimina/api/route/RouteApi.kt
@@ -1,6 +1,5 @@
 package com.didi.dimina.api.route
 
-import android.content.Intent
 import com.didi.dimina.api.APIResult
 import com.didi.dimina.api.AsyncResult
 import com.didi.dimina.api.BaseApiHandler
@@ -107,20 +106,7 @@ class RouteApi : BaseApiHandler() {
                     return ApiUtils.createErrorResponse(apiName, "URL cannot be empty")
                 }
 
-                val miniProgram = activity.getMiniProgram()
-                DiminaActivity.launch(
-                    activity, MiniProgram(
-                        appId = appId,
-                        name = miniProgram.name,
-                        root = true, // Set as root since we're clearing the stack
-                        path = url,
-                        versionCode = miniProgram.versionCode,
-                        versionName = miniProgram.versionName,
-                        updateManifestUrl = miniProgram.updateManifestUrl
-                    ),
-                    // Clear all activities below the top and reuse the top activity if it exists
-                    Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
-                )
+                activity.reLaunchTo(url)
                 AsyncResult(JSONObject().apply {
                     put("errMsg", "$RE_LAUNCH:ok")
                 })

--- a/android/dimina/src/main/kotlin/com/didi/dimina/api/ui/NavigationBarApi.kt
+++ b/android/dimina/src/main/kotlin/com/didi/dimina/api/ui/NavigationBarApi.kt
@@ -13,11 +13,13 @@ class NavigationBarApi : BaseApiHandler() {
     private companion object {
         const val SET_NAVIGATION_BAR_TITLE = "setNavigationBarTitle"
         const val SET_NAVIGATION_BAR_COLOR = "setNavigationBarColor"
+        const val HIDE_HOME_BUTTON = "hideHomeButton"
     }
 
     override val apiNames = setOf(
         SET_NAVIGATION_BAR_TITLE,
         SET_NAVIGATION_BAR_COLOR,
+        HIDE_HOME_BUTTON,
     )
 
     override fun handleAction(
@@ -57,6 +59,13 @@ class NavigationBarApi : BaseApiHandler() {
                 activity.setNavigationBarColor(frontColor, backgroundColor)
                 AsyncResult(JSONObject().apply {
                     put("errMsg", "$SET_NAVIGATION_BAR_COLOR:ok")
+                })
+            }
+
+            HIDE_HOME_BUTTON -> {
+                activity.hideHomeButton()
+                AsyncResult(JSONObject().apply {
+                    put("errMsg", "$HIDE_HOME_BUTTON:ok")
                 })
             }
 

--- a/android/dimina/src/main/kotlin/com/didi/dimina/bean/AppConfig.kt
+++ b/android/dimina/src/main/kotlin/com/didi/dimina/bean/AppConfig.kt
@@ -29,6 +29,7 @@ data class WindowConfig(
     val navigationBarBackgroundColor: String? = null,
     val backgroundColor: String? = null,
     val navigationStyle: String? = null,
+    val homeButton: Boolean? = null,
 )
 
 @Serializable
@@ -71,5 +72,6 @@ data class PageModule(
     val navigationBarTextStyle: String? = null,
     val backgroundColor: String? = null,
     val navigationStyle: String? = null,
+    val homeButton: Boolean? = null,
     val usingComponents: Map<String, String>? = null
 )

--- a/android/dimina/src/main/kotlin/com/didi/dimina/bean/BridgeOptions.kt
+++ b/android/dimina/src/main/kotlin/com/didi/dimina/bean/BridgeOptions.kt
@@ -20,6 +20,8 @@ data class MergedPageConfig(
     val navigationBarTextStyle: String,
     val backgroundColor: String,
     val navigationStyle: String,
+    // 页面配置 homeButton: true 强制显示导航栏返回首页按钮（微信 page.json homeButton 字段）
+    val homeButton: Boolean,
     val usingComponents: Map<String, String>
 )
 

--- a/android/dimina/src/main/kotlin/com/didi/dimina/common/Utils.kt
+++ b/android/dimina/src/main/kotlin/com/didi/dimina/common/Utils.kt
@@ -51,9 +51,11 @@ object Utils {
             return PathInfo("", null)
         }
 
-        // 分离路径和查询字符串
+        // 分离路径和查询字符串。pagePath 统一去除前导斜杠：宿主直启 path（扫码/
+        // 分享）与 wx.* 路由的 "/pages/x/y" 写法都归一到 app-config modules key
+        // 的形态（无前导斜杠），保证 tabBar / 首页判定与页面配置查找不因写法发散
         val parts = url.split("?", limit = 2)
-        val pagePath = parts[0].trim() // 去除首尾空白
+        val pagePath = parts[0].trim().trimStart('/')
 
         // 如果没有查询字符串，返回只有 pagePath 的结果
         if (parts.size == 1) {
@@ -106,6 +108,8 @@ object Utils {
                 ?: appWindowConfig.backgroundColor ?: "#fff",
             navigationStyle = pagePrivateConfig.navigationStyle
                 ?: appWindowConfig.navigationStyle ?: "default",
+            homeButton = pagePrivateConfig.homeButton
+                ?: appWindowConfig.homeButton ?: false,
             usingComponents = pagePrivateConfig.usingComponents ?: emptyMap()
         )
     }

--- a/android/dimina/src/main/kotlin/com/didi/dimina/ui/container/DiminaActivity.kt
+++ b/android/dimina/src/main/kotlin/com/didi/dimina/ui/container/DiminaActivity.kt
@@ -184,8 +184,22 @@ class DiminaActivity : ComponentActivity() {
     // Reference to the MiniApp instance
     private lateinit var miniApp: MiniApp
 
-    // Current MiniProgram
-    private lateinit var miniProgram: MiniProgram
+    // 当前小程序对象，用 Compose state 而非普通 lateinit var 承载：它会在
+    // onNewIntent/applyUpdate 里脱离 composition 被重新赋值，普通字段读取不会
+    // 建立快照订阅——依赖 miniProgram.* 的 composable 只有在同一次重组里恰好
+    // 读了别的会触发失效的 state 时才会跟着更新，这个前提并不总成立。
+    private val miniProgramState = mutableStateOf<MiniProgram?>(null)
+
+    // @JvmName 用来避开跟下面已有的 getMiniProgram() 方法（RouteApi.kt 在用）的
+    // JVM 签名冲突——不加的话 Kotlin 会给这个属性自动生成同名字节码 getter
+    private var miniProgram: MiniProgram
+        @JvmName("miniProgramValue")
+        get() = checkNotNull(miniProgramState.value) { "miniProgram accessed before initialization" }
+        set(value) {
+            miniProgramState.value = value
+        }
+    private val isMiniProgramInitialized: Boolean
+        get() = miniProgramState.value != null
 
     // Contact picker for handling contact-related operations
     private lateinit var contactPicker: ContactPicker
@@ -441,16 +455,8 @@ class DiminaActivity : ComponentActivity() {
         super.onNewIntent(intent)
         setIntent(intent)
 
-        if (intent.getBooleanExtra(APPLY_UPDATE_RESTART_KEY, false)) {
-            getMiniProgramFromIntent(intent)?.let { program ->
-                DiminaActivity.launch(this, program)
-            }
-            finish()
-            return
-        }
-
         val program = getMiniProgramFromIntent(intent) ?: return
-        if (::miniProgram.isInitialized && program.appId != miniProgram.appId) {
+        if (isMiniProgramInitialized && program.appId != miniProgram.appId) {
             return
         }
 
@@ -460,7 +466,7 @@ class DiminaActivity : ComponentActivity() {
             return
         }
 
-        // reLaunch 落到既有 Activity（CLEAR_TOP→onNewIntent）：全部页面实例作废，
+        // 若这个 Activity 实例被复用（intent 落到已存在的顶层实例）：全部页面实例作废，
         // 页面级 hideHomeButton 标记随之重置（TabPageState 会被 switchTab/updatePath 复用，
         // 不重置会把旧页面实例的隐藏标记带进新页面）
         homeButtonHiddenForPage.value = false
@@ -629,8 +635,8 @@ class DiminaActivity : ComponentActivity() {
         // Set navigation bar visibility based on navigationStyle
         showNavigationBar.value = config.navigationStyle != "custom"
 
-        // hideHomeButton() only hides the home button for the page that called it;
-        // it resets whenever the page identity behind this Activity changes
+        // hideHomeButton() 只隐藏调用它的那个页面的 home 按钮；这个 Activity 背后
+        // 的页面身份一变就会重置
         homeButtonHiddenForPage.value = false
         homeButtonForcedByConfig.value = config.homeButton
 
@@ -764,20 +770,24 @@ class DiminaActivity : ComponentActivity() {
         }
 
         if (!miniProgram.root) {
-            DiminaActivity.launch(
-                this,
-                MiniProgram(
-                    appId = miniProgram.appId,
-                    name = miniProgram.name,
-                    root = true,
-                    path = url,
-                    versionCode = miniProgram.versionCode,
-                    versionName = miniProgram.versionName,
-                    updateManifestUrl = miniProgram.updateManifestUrl
-                ),
-                Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
-            )
-            finish()
+            // CLEAR_TOP 按 Activity 组件匹配，清不掉共享同一 DiminaActivity 类的下层
+            // 实例；改用 activityRegistry 精确找到 root 实例并同进程直接调用它的
+            // switchTab，不需要任何 Intent flag
+            val root = activityRegistry.closeAllExcept(
+                miniProgram.appId,
+                keep = { it.miniProgram.root },
+            ) { activity ->
+                activity.preserveMiniAppOnDestroy = true
+                activity.finish()
+            }
+            if (root != null) {
+                root.runOnUiThread {
+                    root.switchTab(url)
+                }
+            } else {
+                // 异常态：栈里没有 root 实例（如宿主直启非 tab 内页），退化为清栈重启
+                relaunchStack(url)
+            }
             return true
         }
 
@@ -1372,7 +1382,7 @@ class DiminaActivity : ComponentActivity() {
     }
 
     override fun onDestroy() {
-        if (::miniProgram.isInitialized) {
+        if (isMiniProgramInitialized) {
             activityRegistry.unregister(miniProgram.appId, this)
         }
 
@@ -1664,13 +1674,12 @@ class DiminaActivity : ComponentActivity() {
     fun applyUpdate() {
         val entryPagePath = getDefaultEntryPagePath() ?: miniProgram.path
         val updatedMiniProgram = miniProgram.copy(root = true, path = entryPagePath)
-        miniApp.clear(miniProgram.appId)
-        val intent = Intent(this, DiminaActivity::class.java).apply {
-            putExtra(MINI_PROGRAM_KEY, updatedMiniProgram)
-            putExtra(APPLY_UPDATE_RESTART_KEY, true)
-            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+        // 不 preserve：更新语义要求冷重启 JS 实例，这是和 reLaunch 的关键区别
+        activityRegistry.closeAll(miniProgram.appId) { activity ->
+            activity.finish()
         }
-        startActivity(intent)
+        miniApp.clear(miniProgram.appId)
+        DiminaActivity.launch(this, updatedMiniProgram)
     }
 
     private fun getDefaultEntryPagePath(): String? {
@@ -1684,20 +1693,21 @@ class DiminaActivity : ComponentActivity() {
      * 清空页面栈并重新打开到 [url]，与 wx.reLaunch 行为一致
      */
     fun reLaunchTo(url: String) {
-        DiminaActivity.launch(
-            this,
-            MiniProgram(
-                appId = miniProgram.appId,
-                name = miniProgram.name,
-                root = true, // Set as root since we're clearing the stack
-                path = url,
-                versionCode = miniProgram.versionCode,
-                versionName = miniProgram.versionName,
-                updateManifestUrl = miniProgram.updateManifestUrl
-            ),
-            // Clear all activities below the top and reuse the top activity if it exists
-            Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
-        )
+        relaunchStack(url)
+    }
+
+    /**
+     * 精确关闭该小程序全部页面 Activity 实例并以新根页重启：preserve=true 因为
+     * wx.reLaunch/switchTab 找不到 root 实例时的兜底都只清页面栈，不重启 JS 实例
+     * （与 applyUpdate 的关键区别）。CLEAR_TOP 只能按 Activity 组件匹配，清不掉
+     * 共享同一 DiminaActivity 类的下层实例，所以改用 activityRegistry 精确关栈
+     */
+    private fun relaunchStack(url: String) {
+        activityRegistry.closeAll(miniProgram.appId) { activity ->
+            activity.preserveMiniAppOnDestroy = true
+            activity.finish()
+        }
+        DiminaActivity.launch(this, miniProgram.copy(root = true, path = url))
     }
 
     /**
@@ -2046,6 +2056,8 @@ class DiminaActivity : ComponentActivity() {
                     state.root = pageConfig?.root ?: "main"
                     state.configInfo = mergedPageConfig
                     state.bridgeStarted = false
+                    // 页面身份被替换，清掉上一任页面的隐藏标记，否则会跨 redirectTo 泄漏到新页面
+                    state.homeButtonHidden.value = false
                 }
 
                 currentBridge.destroy(true)
@@ -2080,7 +2092,6 @@ class DiminaActivity : ComponentActivity() {
 
     companion object {
         const val MINI_PROGRAM_KEY = "mini_program"
-        private const val APPLY_UPDATE_RESTART_KEY = "apply_update_restart"
         private val activityRegistry = MiniProgramActivityRegistry<DiminaActivity>()
 
         fun launch(

--- a/android/dimina/src/main/kotlin/com/didi/dimina/ui/container/DiminaActivity.kt
+++ b/android/dimina/src/main/kotlin/com/didi/dimina/ui/container/DiminaActivity.kt
@@ -45,10 +45,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -61,6 +63,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
@@ -76,6 +79,7 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.toArgb
@@ -146,6 +150,8 @@ class DiminaActivity : ComponentActivity() {
     private val tabBarBadges = mutableStateOf<List<String>>(emptyList())
     private val tabBarRedDots = mutableStateOf<List<Boolean>>(emptyList())
     private val currentPagePath = mutableStateOf("")
+    private val homeButtonHiddenForPage = mutableStateOf(false)
+    private val homeButtonForcedByConfig = mutableStateOf(false)
     private val useTabBarContainer = mutableStateOf(false)
     private val loadedTabIndices = mutableStateOf<Set<Int>>(emptySet())
 
@@ -228,6 +234,8 @@ class DiminaActivity : ComponentActivity() {
         val webViewReadyCallbacks: MutableList<(WebView) -> Unit> = mutableListOf(),
         var pageReadyCallback: (() -> Unit)? = null,
         var bridgeStarted: Boolean = false,
+        // wx.hideHomeButton 按页面（tab）实例记账：后台 tab 的迟到调用只影响自己
+        val homeButtonHidden: MutableState<Boolean> = mutableStateOf(false),
     )
 
 
@@ -452,6 +460,12 @@ class DiminaActivity : ComponentActivity() {
             return
         }
 
+        // reLaunch 落到既有 Activity（CLEAR_TOP→onNewIntent）：全部页面实例作废，
+        // 页面级 hideHomeButton 标记随之重置（TabPageState 会被 switchTab/updatePath 复用，
+        // 不重置会把旧页面实例的隐藏标记带进新页面）
+        homeButtonHiddenForPage.value = false
+        tabPageStates.values.forEach { it.homeButtonHidden.value = false }
+
         if (isTabBarPageUrl(url)) {
             switchTab(url)
         } else {
@@ -615,6 +629,11 @@ class DiminaActivity : ComponentActivity() {
         // Set navigation bar visibility based on navigationStyle
         showNavigationBar.value = config.navigationStyle != "custom"
 
+        // hideHomeButton() only hides the home button for the page that called it;
+        // it resets whenever the page identity behind this Activity changes
+        homeButtonHiddenForPage.value = false
+        homeButtonForcedByConfig.value = config.homeButton
+
         // Set navigation bar title
         navigationBarTitle.value = config.navigationBarTitleText
 
@@ -679,6 +698,58 @@ class DiminaActivity : ComponentActivity() {
             return false
         }
         return getTabBarIndex(Utils.queryPath(url).pagePath) >= 0
+    }
+
+    /**
+     * 导航栏「返回首页」按钮的显示判据（微信真机实测语义）：默认导航栏 + 未被
+     * hideHomeButton 隐藏 + 当前页非应用首页 + 非 tabBar 页（这两条排除
+     * homeButton: true 也不能突破），且满足其一：页面栈栈底（自动规则），
+     * 或页面配置 homeButton: true（此时与返回箭头并存显示）
+     */
+    private fun shouldShowHomeButton(): Boolean {
+        if (!::appConfig.isInitialized) {
+            return false
+        }
+        if (!showNavigationBar.value || activePageHomeButtonHidden()) {
+            return false
+        }
+        // 归一化前导斜杠再比较：currentPagePath 可能来自宿主直启 path，
+        // entryPagePath 来自配置，两者写法不受控
+        val pagePath = currentPagePath.value.trimStart('/')
+        if (pagePath.isEmpty() || pagePath == getDefaultEntryPagePath()?.trimStart('/')) {
+            return false
+        }
+        if (getTabBarIndex(pagePath) >= 0) {
+            return false
+        }
+        return miniProgram.root || homeButtonForcedByConfig.value
+    }
+
+    /**
+     * 当前可见页面的 hideHomeButton 标记：tab 容器下读当前选中 tab 自己的标记，
+     * 非 tab 根页面读 activity 级标记（一个 Activity 只承载一个非 tab 页，
+     * redirectTo/reLaunch 换页时在 setInitialStyle 重置）
+     */
+    private fun activePageHomeButtonHidden(): Boolean {
+        if (useTabBarContainer.value) {
+            tabPageStates[selectedTabIndex.intValue]?.let { return it.homeButtonHidden.value }
+        }
+        return homeButtonHiddenForPage.value
+    }
+
+    /**
+     * 隐藏调用页的返回首页按钮（wx.hideHomeButton）。经 apiBridgeContext 归属调用方：
+     * tab 页标记在自己的 TabPageState 上——后台 tab 的迟到调用不会隐藏当前可见 tab 的按钮
+     */
+    fun hideHomeButton() {
+        val caller = apiBridgeContext
+        if (caller != null) {
+            tabPageStates.values.firstOrNull { it.bridge === caller }?.let { state ->
+                state.homeButtonHidden.value = true
+                return
+            }
+        }
+        homeButtonHiddenForPage.value = true
     }
 
     fun switchTab(url: String): Boolean {
@@ -810,8 +881,11 @@ class DiminaActivity : ComponentActivity() {
     }
 
     private fun getTabBarIndex(pagePath: String): Int {
+        // 两侧都归一化前导斜杠：pagePath 可能来自宿主直启 path 或 config，
+        // tabBar.list 的 pagePath 也是配置值，写法不受控
+        val normalized = pagePath.trimStart('/')
         return appConfig.app.tabBar?.list?.indexOfFirst { item ->
-            item.pagePath == pagePath
+            item.pagePath.trimStart('/') == normalized
         } ?: -1
     }
 
@@ -1405,13 +1479,48 @@ class DiminaActivity : ComponentActivity() {
                                 containerColor = navBarBgColor
                             ),
                             navigationIcon = {
-                                IconButton(onClick = { finish() }) {
-                                    Icon(
-                                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
-                                        contentDescription = "Back",
-                                        tint = navigationBarTextColor.value,
-                                        modifier = Modifier.size(30.dp)
-                                    )
+                                // 返回箭头（非栈底页面）与返回首页按钮可并存：
+                                // 页面配置 homeButton: true 的内页两者同时显示（微信实测样式）。
+                                // 两个 IconButton 默认触摸热区都比各自图标大（自带留白），
+                                // 不再额外叠加 Row 间距，否则视觉间距会远超微信原生
+                                // `.navigator-hd a+a{margin-left:10px}` 的 10dp
+                                Row {
+                                    if (!miniProgram.root) {
+                                        IconButton(onClick = { finish() }) {
+                                            Icon(
+                                                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                                                contentDescription = "Back",
+                                                tint = navigationBarTextColor.value,
+                                                modifier = Modifier.size(30.dp)
+                                            )
+                                        }
+                                    }
+                                    if (shouldShowHomeButton()) {
+                                        IconButton(onClick = { navigateHome() }) {
+                                            // 微信真机 home 图标带灰色圆形底，比返回箭头更粗更显眼；
+                                            // 圆底色随导航栏深浅切换（浅色导航栏用深灰，深色导航栏用半透明白）
+                                            Box(
+                                                modifier = Modifier
+                                                    .size(32.dp)
+                                                    .clip(CircleShape)
+                                                    .background(
+                                                        if (navigationBarTextColor.value == Color.White) {
+                                                            Color(0x3DFFFFFF)
+                                                        } else {
+                                                            Color(0xFFD6D6D6)
+                                                        }
+                                                    ),
+                                                contentAlignment = Alignment.Center
+                                            ) {
+                                                Icon(
+                                                    imageVector = Icons.Filled.Home,
+                                                    contentDescription = "Home",
+                                                    tint = navigationBarTextColor.value,
+                                                    modifier = Modifier.size(20.dp)
+                                                )
+                                            }
+                                        }
+                                    }
                                 }
                             },
                             actions = {
@@ -1569,6 +1678,41 @@ class DiminaActivity : ComponentActivity() {
             return null
         }
         return appConfig.app.entryPagePath ?: appConfig.app.pages.firstOrNull()
+    }
+
+    /**
+     * 清空页面栈并重新打开到 [url]，与 wx.reLaunch 行为一致
+     */
+    fun reLaunchTo(url: String) {
+        DiminaActivity.launch(
+            this,
+            MiniProgram(
+                appId = miniProgram.appId,
+                name = miniProgram.name,
+                root = true, // Set as root since we're clearing the stack
+                path = url,
+                versionCode = miniProgram.versionCode,
+                versionName = miniProgram.versionName,
+                updateManifestUrl = miniProgram.updateManifestUrl
+            ),
+            // Clear all activities below the top and reuse the top activity if it exists
+            Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
+        )
+    }
+
+    /**
+     * 返回首页（导航栏 home 按钮的唯一路由入口），终态都是只剩首页：
+     * 首页是 tab 页走 switchTab（保留其它 tab 状态并露出 tabBar，自带清非 tab 栈）；
+     * 首页非 tab 且当前是栈底，按 redirectTo 语义原地换页（updatePath）；
+     * 非栈底（homeButton: true 的内页）须清整栈，走 reLaunchTo
+     */
+    private fun navigateHome() {
+        val entryPagePath = getDefaultEntryPagePath() ?: return
+        when {
+            getTabBarIndex(entryPagePath) >= 0 -> switchTab(entryPagePath)
+            miniProgram.root -> updatePath(entryPagePath)
+            else -> reLaunchTo(entryPagePath)
+        }
     }
 
     @OptIn(ExperimentalMaterial3Api::class)

--- a/android/dimina/src/main/kotlin/com/didi/dimina/ui/container/MiniProgramActivityRegistry.kt
+++ b/android/dimina/src/main/kotlin/com/didi/dimina/ui/container/MiniProgramActivityRegistry.kt
@@ -1,10 +1,10 @@
 package com.didi.dimina.ui.container
 
 /**
- * Tracks the Android activities that form a mini program's page stack.
+ * 追踪构成小程序页面栈的 Android Activity 实例。
  *
- * Every page is hosted by the same Activity class, so Android's component-based
- * CLEAR_TOP lookup cannot distinguish the root page from the current page.
+ * 所有页面复用同一个 Activity 类，系统按组件类型做的 CLEAR_TOP 查找
+ * 无法区分根页面和当前页面。
  */
 internal class MiniProgramActivityRegistry<T> {
     private val activitiesByAppId = mutableMapOf<String, LinkedHashSet<T>>()
@@ -28,5 +28,29 @@ internal class MiniProgramActivityRegistry<T> {
             activitiesByAppId.remove(appId)?.toList().orEmpty()
         }
         activities.asReversed().forEach(close)
+    }
+
+    /**
+     * 关闭 [appId] 下除 [keep] 匹配到的那个之外的所有 Activity（多个匹配时取注册
+     * 顺序里第一个）。保留的 Activity 继续留在账本里，其余按 [closeAll] 同样的
+     * 从上到根顺序关闭。返回被保留的 Activity；没有匹配到时等价于 [closeAll]，
+     * 返回 null。
+     *
+     * 读取账本快照和决定保留谁，与 register/unregister 共用同一把锁做原子操作，
+     * 避免读到并发生命周期变化的中间状态。
+     */
+    fun closeAllExcept(appId: String, keep: (T) -> Boolean, close: (T) -> Unit): T? {
+        val (kept, toClose) = synchronized(this) {
+            val activities = activitiesByAppId[appId]?.toList().orEmpty()
+            val keptActivity = activities.firstOrNull(keep)
+            if (keptActivity != null) {
+                activitiesByAppId[appId] = linkedSetOf(keptActivity)
+            } else {
+                activitiesByAppId.remove(appId)
+            }
+            keptActivity to activities.filter { it !== keptActivity }
+        }
+        toClose.asReversed().forEach(close)
+        return kept
     }
 }

--- a/android/dimina/src/test/java/com/didi/dimina/ui/container/MiniProgramActivityRegistryTest.kt
+++ b/android/dimina/src/test/java/com/didi/dimina/ui/container/MiniProgramActivityRegistryTest.kt
@@ -1,6 +1,8 @@
 package com.didi.dimina.ui.container
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class MiniProgramActivityRegistryTest {
@@ -30,5 +32,97 @@ class MiniProgramActivityRegistryTest {
         registry.closeAll("app", closed::add)
 
         assertEquals(listOf("root"), closed)
+    }
+
+    @Test
+    fun `closeAllExcept closes every other page in top to root order and returns the kept page`() {
+        val registry = MiniProgramActivityRegistry<String>()
+        registry.register("app-a", "root")
+        registry.register("app-a", "page-1")
+        registry.register("app-a", "page-2")
+        registry.register("app-a", "page-3")
+
+        val closed = mutableListOf<String>()
+        val kept = registry.closeAllExcept("app-a", { it == "page-1" }, closed::add)
+
+        assertEquals("page-1", kept)
+        assertEquals(listOf("page-3", "page-2", "root"), closed)
+    }
+
+    @Test
+    fun `closeAllExcept closes every page and returns null when no page matches keep`() {
+        val registry = MiniProgramActivityRegistry<String>()
+        registry.register("app-a", "root")
+        registry.register("app-a", "page-1")
+        registry.register("app-a", "page-2")
+
+        val closed = mutableListOf<String>()
+        val kept = registry.closeAllExcept("app-a", { false }, closed::add)
+
+        assertNull(kept)
+        assertEquals(listOf("page-2", "page-1", "root"), closed)
+    }
+
+    @Test
+    fun `closeAllExcept closes nothing when the only registered page matches keep`() {
+        val registry = MiniProgramActivityRegistry<String>()
+        registry.register("app-a", "root")
+
+        val closed = mutableListOf<String>()
+        val kept = registry.closeAllExcept("app-a", { it == "root" }, closed::add)
+
+        assertEquals("root", kept)
+        assertTrue(closed.isEmpty())
+    }
+
+    @Test
+    fun `closeAllExcept leaves pages registered under other appIds untouched`() {
+        val registry = MiniProgramActivityRegistry<String>()
+        registry.register("app-a", "root")
+        registry.register("app-a", "page-1")
+        registry.register("app-b", "other-app-root")
+
+        val closedA = mutableListOf<String>()
+        registry.closeAllExcept("app-a", { it == "root" }, closedA::add)
+
+        // app-b's bucket must be untouched by the app-a call: if it had been drained too,
+        // this closeAll would have nothing left to invoke close() on.
+        val closedB = mutableListOf<String>()
+        registry.closeAll("app-b", closedB::add)
+
+        assertEquals(listOf("page-1"), closedA)
+        assertEquals(listOf("other-app-root"), closedB)
+    }
+
+    @Test
+    fun `closeAllExcept keeps the matched page registered so a later closeAll still closes it`() {
+        val registry = MiniProgramActivityRegistry<String>()
+        registry.register("app-a", "root")
+        registry.register("app-a", "page-1")
+
+        val firstClosed = mutableListOf<String>()
+        val kept = registry.closeAllExcept("app-a", { it == "root" }, firstClosed::add)
+        assertEquals("root", kept)
+        assertEquals(listOf("page-1"), firstClosed)
+
+        // The kept page must remain in the registry's ledger, not merely be returned by value.
+        val secondClosed = mutableListOf<String>()
+        registry.closeAll("app-a", secondClosed::add)
+        assertEquals(listOf("root"), secondClosed)
+    }
+
+    @Test
+    fun `closeAllExcept keeps the first matching page in registration order when multiple pages match keep`() {
+        val registry = MiniProgramActivityRegistry<String>()
+        registry.register("app-a", "root")
+        registry.register("app-a", "page-1")
+        registry.register("app-a", "page-2")
+        registry.register("app-a", "page-3")
+
+        val closed = mutableListOf<String>()
+        val kept = registry.closeAllExcept("app-a", { it == "page-1" || it == "page-2" }, closed::add)
+
+        assertEquals("page-1", kept)
+        assertEquals(listOf("page-3", "page-2", "root"), closed)
     }
 }

--- a/fe/packages/container/__tests__/query-path.spec.js
+++ b/fe/packages/container/__tests__/query-path.spec.js
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { queryPath } from '../src/utils/util'
+
+// 守护 queryPath 的前导斜杠归一化：app-config.json 的 modules key 与 AMD module id
+// 均为无前导斜杠形态，宿主直启 path 与容器内 "/pages/x/y" 写法必须在此单点归一，
+// 否则页面配置查找与 service 模块加载会因写法发散而失败
+describe('queryPath leading-slash normalization', () => {
+	it('strips a leading slash so the path matches app-config module keys', () => {
+		expect(queryPath('/pages/index/index').pagePath).toBe('pages/index/index')
+	})
+
+	it('strips repeated leading slashes', () => {
+		expect(queryPath('//pages/index/index').pagePath).toBe('pages/index/index')
+	})
+
+	it('keeps already-normalized paths and query parsing intact', () => {
+		const { pagePath, query } = queryPath('pages/detail/detail?id=1')
+		expect(pagePath).toBe('pages/detail/detail')
+		expect(query).toEqual({ id: '1' })
+	})
+
+	it('normalizes the path part of a slash-prefixed url with query', () => {
+		const { pagePath, query } = queryPath('/pages/detail/detail?id=1&from=share')
+		expect(pagePath).toBe('pages/detail/detail')
+		expect(query).toEqual({ id: '1', from: 'share' })
+	})
+})

--- a/fe/packages/container/src/core/bridge.js
+++ b/fe/packages/container/src/core/bridge.js
@@ -117,8 +117,9 @@ export class Bridge {
 		else if (target === 'container') {
 			if (type === 'invokeAPI') {
 				const { name, params } = body
-				// parent 是 miniApp 对象
-				this.parent.invokeApi(name, params)
+				// parent 是 miniApp 对象；带上调用方 bridge，让 hideHomeButton 这类
+				// 作用于"调用页自身"的 API 能定位到正确的页面
+				this.parent.invokeApi(name, params, this)
 			}
 		}
 	}
@@ -190,6 +191,12 @@ export class Bridge {
 			const webview = new WebView({
 				configInfo: this.opts.configInfo,
 				isRoot: this.opts.isRoot,
+				// 返回首页按钮显隐的权威判据在 miniApp（它掌握 entryPagePath / tabBar）
+				showHomeButton: this.parent.shouldShowHomeButton({
+					pagePath: this.opts.pagePath,
+					configInfo: this.opts.configInfo,
+					isRoot: this.opts.isRoot,
+				}),
 			})
 
 			webview.parent = this

--- a/fe/packages/container/src/pages/miniApp/miniApp.js
+++ b/fe/packages/container/src/pages/miniApp/miniApp.js
@@ -88,6 +88,69 @@ export class MiniApp {
 		return this.appInfo.pagePath || this.appConfig?.app?.entryPagePath || ''
 	}
 
+	/**
+	 * 应用首页——返回首页按钮的跳转目标与其显示判据的比较对象。
+	 * 取配置声明的 entryPagePath（缺省 pages[0]），不受 deep-link 启动页影响。
+	 */
+	getHomePagePath() {
+		return this._normalizePagePath(this.appConfig?.app?.entryPagePath || this.appConfig?.app?.pages?.[0] || '')
+	}
+
+	/**
+	 * 返回首页按钮显示判据（微信真机实测语义）：默认导航栏 + 当前页非应用首页 +
+	 * 非 tabBar 页（这两条排除 homeButton: true 也不能突破），且满足其一：
+	 * 栈底页面（自动规则），或页面配置 homeButton: true（此时与返回箭头并存）。
+	 * wx.hideHomeButton 的隐藏作用在 webview 上（setHomeButtonVisible），不在这里
+	 */
+	shouldShowHomeButton({ pagePath, configInfo, isRoot }) {
+		if (configInfo?.navigationStyle === 'custom') {
+			return false
+		}
+		const homePagePath = this.getHomePagePath()
+		if (!homePagePath) {
+			return false
+		}
+		const normalized = this._normalizePagePath(pagePath)
+		if (this._isTabBarPage(normalized) || normalized === homePagePath) {
+			return false
+		}
+		return isRoot || configInfo?.homeButton === true
+	}
+
+	/**
+	 * 返回首页（导航栏 home 按钮的唯一路由入口），终态都是只剩首页：
+	 * 首页是 tab 页走 switchTab（保留其它 tab 状态并露出 tabBar，自带清非 tab 栈）；
+	 * 首页非 tab 且当前是栈底，redirectTo 原地替换；非栈底（homeButton: true 的
+	 * 内页）redirect 只会替换栈顶、栈底仍在，须 reLaunch 清整栈
+	 */
+	navigateHome() {
+		const homePagePath = this.getHomePagePath()
+		if (!homePagePath) {
+			return
+		}
+		if (this._isTabBarPage(homePagePath)) {
+			this.switchTab({ url: `/${homePagePath}` })
+		}
+		else if (this.bridgeList.length <= 1) {
+			this.redirectTo({ url: `/${homePagePath}` })
+		}
+		else {
+			this.reLaunch({ url: `/${homePagePath}` })
+		}
+	}
+
+	/**
+	 * wx.hideHomeButton：隐藏调用页自己的返回首页按钮。经 bridge 归属调用方，
+	 * 后台页的迟到调用不会隐藏当前可见页面的按钮
+	 */
+	hideHomeButton(opts = {}, callerBridge) {
+		const { onSuccess, onComplete } = this._createApiCallbacks(opts)
+		const bridge = callerBridge || this.bridgeList[this.bridgeList.length - 1]
+		bridge?.webview?.setHomeButtonVisible(false)
+		onSuccess?.({ errMsg: 'hideHomeButton:ok' })
+		onComplete?.()
+	}
+
 	async copyText(text, successText) {
 		try {
 			if (navigator.clipboard?.writeText) {
@@ -212,14 +275,16 @@ export class MiniApp {
 	 * 按名称调用 API，优先查找自定义注册 → 内置方法 → 第三方扩展路由
 	 * @param {string} name API 名称
 	 * @param {object} params API 参数
+	 * @param {Bridge} [callerBridge] 发起调用的页面 bridge，作用于"调用页自身"的
+	 *   API（如 hideHomeButton）用它定位页面
 	 */
-	invokeApi(name, params) {
+	invokeApi(name, params, callerBridge) {
 		const handler = this.apiRegistry[name]
 		if (handler) {
-			handler.call(this, params)
+			handler.call(this, params, callerBridge)
 		}
 		else if (typeof this[name] === 'function') {
-			this[name](params)
+			this[name](params, callerBridge)
 		}
 		else if (params?.module !== undefined || params?.evtId !== undefined) {
 			// 扩展调用必须携带明确的协议标记，不能仅凭 success 判断，
@@ -717,6 +782,16 @@ export class MiniApp {
 				query,
 				configInfo: mergeConfig,
 			}
+			// webview 被新页面复用：按新页面身份重刷导航栏（标题/配色/自定义导航），
+			// 返回首页按钮显隐也随之重算（wx.hideHomeButton 的标记属于旧页面，不延续）
+			curBridge.webview.applyPageStyle(mergeConfig, {
+				isRoot: curBridge.opts.isRoot,
+				showHomeButton: this.shouldShowHomeButton({
+					pagePath,
+					configInfo: mergeConfig,
+					isRoot: curBridge.opts.isRoot,
+				}),
+			})
 			curBridge.resetStatus()
 			curBridge.start()
 			this._syncHash()

--- a/fe/packages/container/src/pages/webview/webview.html
+++ b/fe/packages/container/src/pages/webview/webview.html
@@ -3,6 +3,7 @@
 	<div class="dimina-native-webview__navigation">
 		<div class="dimina-native-webview__navigation-content">
 			<div class="dimina-native-webview__navigation-left-btn"></div>
+			<div class="dimina-native-webview__navigation-home-btn"></div>
 			<h2 class="dimina-native-webview__navigation-title"></h2>
 		</div>
 	</div>

--- a/fe/packages/container/src/pages/webview/webview.js
+++ b/fe/packages/container/src/pages/webview/webview.js
@@ -17,6 +17,7 @@ export class WebView {
 		this.iframe.name = this.id
 		this.event = mitt()
 		this.bindBackEvent()
+		this.bindHomeEvent()
 	}
 
 	async init(callback) {
@@ -60,6 +61,23 @@ export class WebView {
 		}
 	}
 
+	bindHomeEvent() {
+		const homeBtn = this.el.querySelector('.dimina-native-webview__navigation-home-btn')
+
+		homeBtn.onclick = () => {
+			this.parent.parent.navigateHome()
+		}
+	}
+
+	/**
+	 * 返回首页按钮的显隐。显示判据由 MiniApp.shouldShowHomeButton 统一给出，
+	 * wx.hideHomeButton 也经这里隐藏调用页自己的按钮
+	 */
+	setHomeButtonVisible(visible) {
+		const homeBtn = this.el.querySelector('.dimina-native-webview__navigation-home-btn')
+		homeBtn.style.display = visible ? 'block' : 'none'
+	}
+
 	frameLoaded() {
 		return new Promise((resolve) => {
 			this.iframe.onload = () => {
@@ -72,31 +90,44 @@ export class WebView {
 	 * 设置初始化样式: 导航栏、背景色、标题栏
 	 */
 	setInitialStyle() {
-		const config = this.opts.configInfo
+		this.applyPageStyle(this.opts.configInfo, {
+			isRoot: this.opts.isRoot,
+			showHomeButton: this.opts.showHomeButton === true,
+		})
+	}
+
+	/**
+	 * 应用页面级导航栏/背景样式。幂等：redirectTo 复用当前 webview 承载新页面时
+	 * 会用新页面的配置重新调用（同时按新页面身份重算返回首页按钮的显隐）
+	 */
+	applyPageStyle(config, { isRoot, showHomeButton }) {
 		const webview = this.el.querySelector('.dimina-native-webview')
 		const pageName = this.el.querySelector('.dimina-native-webview__navigation-title')
 		const navigationBar = this.el.querySelector('.dimina-native-webview__navigation')
 		const leftBtn = this.el.querySelector('.dimina-native-webview__navigation-left-btn')
 		const root = this.el.querySelector('.dimina-native-webview__root')
 
-		// 小程序首页没有返回按钮
-		if (this.opts.isRoot) {
-			leftBtn.style.display = 'none'
-		}
-		else {
-			leftBtn.style.display = 'block'
-		}
+		// 返回箭头只出现在非栈底页面；返回首页按钮独立判定（homeButton: true 的
+		// 内页两者并存，home 键让出左槽紧随箭头之后）
+		leftBtn.style.display = isRoot ? 'none' : 'block'
+		this.setHomeButtonVisible(showHomeButton === true)
+		const homeBtn = this.el.querySelector('.dimina-native-webview__navigation-home-btn')
+		homeBtn.classList.toggle(
+			'dimina-native-webview__navigation-home-btn--after-back',
+			!isRoot && showHomeButton === true,
+		)
 
-		if (config.navigationBarTextStyle === 'white') {
-			navigationBar.classList.add('dimina-native-webview__navigation--white')
-		}
-		else {
-			navigationBar.classList.add('dimina-native-webview__navigation--black')
-		}
+		navigationBar.classList.remove(
+			'dimina-native-webview__navigation--white',
+			'dimina-native-webview__navigation--black',
+		)
+		navigationBar.classList.add(
+			config.navigationBarTextStyle === 'white'
+				? 'dimina-native-webview__navigation--white'
+				: 'dimina-native-webview__navigation--black',
+		)
 
-		if (config.navigationStyle === 'custom') {
-			webview.classList.add('dimina-native-webview--custom-nav')
-		}
+		webview.classList.toggle('dimina-native-webview--custom-nav', config.navigationStyle === 'custom')
 
 		root.style.backgroundColor = config.backgroundColor
 		navigationBar.style.backgroundColor = config.navigationBarBackgroundColor

--- a/fe/packages/container/src/pages/webview/webview.scss
+++ b/fe/packages/container/src/pages/webview/webview.scss
@@ -42,6 +42,28 @@
 			top: 0;
 			cursor: pointer;
 		}
+
+		// 返回首页按钮：栈底页面独占左槽；homeButton: true 的内页与返回箭头
+		// 并存（--after-back 修饰类，见 WebView.applyPageStyle）。带灰色圆形底
+		// （对齐微信真机 home 图标视觉权重），并存间距 20rpx（=10pt）对齐微信
+		// 原生导航栏 `.navigator-hd a+a{margin-left:10px}`
+		.dimina-native-webview__navigation-home-btn {
+			width: logic(64px);
+			height: logic(64px);
+			position: absolute;
+			left: logic(30px);
+			top: logic(12px);
+			cursor: pointer;
+			display: none;
+			border-radius: 50%;
+			background-repeat: no-repeat;
+			background-position: center;
+			background-size: logic(40px) logic(40px);
+
+			&.dimina-native-webview__navigation-home-btn--after-back {
+				left: logic(74px);
+			}
+		}
 	}
 
 	.dimina-native-webview__navigation-title {
@@ -58,6 +80,12 @@
 			background: url('@images/mini-arrow-left-white.png') no-repeat left center;
 			background-size: logic(20px) logic(35px);
 		}
+
+		// Material Icons 的 home 造型，与返回箭头位图同属 Material 图标体系
+		.dimina-native-webview__navigation-home-btn {
+			background-color: rgba(255, 255, 255, 0.24);
+			background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z' fill='%23fff'/%3E%3C/svg%3E");
+		}
 	}
 
 	&.dimina-native-webview__navigation--black {
@@ -68,6 +96,11 @@
 		.dimina-native-webview__navigation-left-btn {
 			background: url('@images/mini-arrow-left.png') no-repeat left center;
 			background-size: logic(20px) logic(35px);
+		}
+
+		.dimina-native-webview__navigation-home-btn {
+			background-color: #d6d6d6;
+			background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z' fill='%23000'/%3E%3C/svg%3E");
 		}
 	}
 }

--- a/fe/packages/container/src/utils/util.js
+++ b/fe/packages/container/src/utils/util.js
@@ -22,7 +22,10 @@ export function waitForTransitionEnd(element) {
 
 export function queryPath(path) {
 	const parts = path.split('?')
-	const pagePath = parts[0]
+	// pagePath 统一去除前导斜杠：app-config.json 的 modules key 与 AMD module id
+	// 都是无前导斜杠形态，宿主直启 path 与容器内 "/pages/x/y" 写法都在此单点归一，
+	// 否则页面配置查找与 service 模块加载会因写法发散而失败
+	const pagePath = parts[0].replace(/^\/+/, '')
 	const paramStr = parts[1]
 
 	const result = {
@@ -83,6 +86,7 @@ export function mergePageConfig(appConfig, pageConfig) {
 	result.navigationBarTextStyle = pagePrivateConfig.navigationBarTextStyle || appWindowConfig.navigationBarTextStyle || 'white'
 	result.backgroundColor = pagePrivateConfig.backgroundColor || appWindowConfig.backgroundColor || '#fff'
 	result.navigationStyle = pagePrivateConfig.navigationStyle || appWindowConfig.navigationStyle || 'default'
+	result.homeButton = pagePrivateConfig.homeButton ?? appWindowConfig.homeButton ?? false
 	result.usingComponents = pagePrivateConfig.usingComponents || {}
 
 	return result

--- a/fe/packages/service/src/api/core/ui/navigation-bar/index.js
+++ b/fe/packages/service/src/api/core/ui/navigation-bar/index.js
@@ -31,3 +31,11 @@ export function setNavigationBarColor(opts) {
 export function hideNavigationBarLoading(opts) {
 	return invokeAPI('hideNavigationBarLoading', opts)
 }
+
+/**
+ * 隐藏当前页面导航条左侧的返回首页按钮
+ * https://developers.weixin.qq.com/miniprogram/dev/api/ui/navigation-bar/wx.hideHomeButton.html
+ */
+export function hideHomeButton(opts) {
+	return invokeAPI('hideHomeButton', opts)
+}

--- a/harmony/dimina/src/main/ets/Bridges/DMPContainerBridgesModule+NavigationBar.ets
+++ b/harmony/dimina/src/main/ets/Bridges/DMPContainerBridgesModule+NavigationBar.ets
@@ -9,7 +9,7 @@ import { DMPBridgeCallback } from './DMPTSUtil';
 export class DMPContainerBridgesModuleNavigationBar extends DMPContainerBridgesModule {
   getExportMethods(): string[] {
     return ['setNavigationBarTitle', 'setNavigationBarColor', 'setNavigationTitleColor', 'showNavigationBar',
-      'hideNavigationBar'];
+      'hideNavigationBar', 'hideHomeButton'];
   }
 
   setNavigationBarTitle(data: DMPMap, callback: DMPBridgeCallback, webViewId: number) {
@@ -60,6 +60,20 @@ export class DMPContainerBridgesModuleNavigationBar extends DMPContainerBridgesM
     navStyle.set('isHide', true)
     this.app.navigatorManager.getPageRecordById(webViewId)!.pageStyle =
       new DMPPageStyle(navStyle ?? new DMPMap(), this.app.appIndex)
+    this.invokeSuccessCallback(callback, null)
+  }
+
+  // 微信语义：仅支持隐藏，无对应的显示 API；隐藏后该页面实例生命周期内不再恢复
+  hideHomeButton(data: DMPMap, callback: DMPBridgeCallback, webViewId: number) {
+    // 页面销毁 / reLaunch 清栈后的迟到调用按 fail 返回，不崩容器
+    const record = this.app.navigatorManager.getPageRecordById(webViewId)
+    if (!record) {
+      this.invokeFailureCallback(callback, null, 'hideHomeButton:fail page not found')
+      return
+    }
+    const navStyle = DMPMap.createFromDMPMap(record.pageStyle?.navStyle)
+    navStyle.set('hideHomeButton', true)
+    record.pageStyle = new DMPPageStyle(navStyle ?? new DMPMap(), this.app.appIndex)
     this.invokeSuccessCallback(callback, null)
   }
 }

--- a/harmony/dimina/src/main/ets/Bundle/Model/DMPBundleAppConfigNext.ets
+++ b/harmony/dimina/src/main/ets/Bundle/Model/DMPBundleAppConfigNext.ets
@@ -89,7 +89,8 @@ export class DMPBundleAppConfigNext {
     if (!this._entryPagePath || !this._entryPagePath.length) {
       this._entryPagePath = this.pages![0]
     }
-    return this._entryPagePath
+    // 权威 getter 统一输出无前导斜杠路径，与页面栈/模块表的 key 口径一致
+    return this._entryPagePath.replace(/^\/+/, '')
   }
 
   set entryPagePath(path: string) {
@@ -111,6 +112,8 @@ export class DMPBundleAppConfigNext {
       pagePrivateConfig['backgroundColor'] || appWindowConfig['backgroundColor'] || '#fff');
     mergedConfig.set('navigationStyle',
       pagePrivateConfig['navigationStyle'] || appWindowConfig['navigationStyle'] || 'default');
+    mergedConfig.set('homeButton',
+      pagePrivateConfig['homeButton'] ?? appWindowConfig['homeButton'] ?? false);
     mergedConfig.set('usingComponents', pagePrivateConfig['usingComponents'] || {});
 
     return mergedConfig;

--- a/harmony/dimina/src/main/ets/DApp/DMPApp.ets
+++ b/harmony/dimina/src/main/ets/DApp/DMPApp.ets
@@ -461,6 +461,11 @@ export class DMPApp {
     if (!launchConfig.appEntryPath) {
       launchConfig.appEntryPath = this.bundleManager.getJsAppModuleConfig().entryPagePath
     }
+    // 启动页路径统一去除前导斜杠：宿主 launchConfig / bundle config 的写法不受控，
+    // 而 app-config 的 modules / tabBar key 均无前导斜杠。页面内路由都经
+    // DataTransformer.parse 归一化，启动链路绕过它，故在此单点补闸，
+    // 否则页面配置查找与首页/tabBar 判定会因写法发散
+    launchConfig.appEntryPath = launchConfig.appEntryPath?.replace(/^\/+/, '') ?? ''
     if (launchConfig.popListener) {
       this.navigatorManager.registerPopListener(launchConfig.popListener)
     }

--- a/harmony/dimina/src/main/ets/DApp/DMPApp.ets
+++ b/harmony/dimina/src/main/ets/DApp/DMPApp.ets
@@ -176,6 +176,15 @@ export class DMPApp {
       pageCount -= 1;
     }
     curNavigator?.navigateBack(pageCount, false, false, true);
+    // navigateBack -> pop() 内部没有真正的 await，上面这一行已经同步跑完：当前 navigator
+    // 清完栈后，pop() 里 `_stacks.size() < 1` 的分支会把它自己从 navigatorManager 摘除。
+    // 此时账本里如果还剩 navigator，就是本次 reLaunch 从未触碰过的下层 navigator（问题
+    // 场景：customLaunchPageCallBack/openType=Insert 让宿主在已有 navigator 上插入了第二
+    // 层）——不清掉的话它们会在共享 NavPathStack 里永久残留。复用现有的批量关闭能力，不
+    // 单独实现一套清栈逻辑
+    if (!this.navigatorManager.isEmpty()) {
+      this.navigatorManager.closeAllNavigators(false)
+    }
     //为什么延时，因为鸿蒙pop和push 会相互抵消，导致页面不能正常关闭
     setTimeout(() => {
       if (config) {

--- a/harmony/dimina/src/main/ets/DPages/DMPPageStyle.ets
+++ b/harmony/dimina/src/main/ets/DPages/DMPPageStyle.ets
@@ -70,6 +70,35 @@ export class DMPPageStyle {
     return this.navStyle.get('navigationStyle') === "custom";
   }
 
+  /**
+   * 微信规则（真机实测语义）：默认导航栏 + 非应用首页（entryPagePath，缺省取 pages[0]）+
+   * 非 tabBar 页（这两条排除 homeButton: true 也不能突破），且满足其一：页面栈栈底（自动规则），
+   * 或页面配置 homeButton: true（此时与返回箭头并存显示）。
+   * wx.hideHomeButton() 通过 navStyle 的 hideHomeButton 标记强制隐藏，优先级最高（见 DMPContainerBridgesModuleNavigationBar）。
+   */
+  shouldShowHomeButton(webViewId: number): boolean {
+    if (this.isCustomPage()) {
+      return false;
+    }
+    if (this.navStyle.get('hideHomeButton') === true) {
+      return false;
+    }
+    const app = DMPAppManager.sharedInstance().getApp(this.appIndex);
+    if (!app) {
+      return false;
+    }
+    const pagePath = app.navigatorManager.getPageRecordById(webViewId)?.pagePath;
+    const appConfig = app.bundleManager.getJsAppModuleConfig();
+    if (!pagePath || !appConfig || !appConfig.entryPagePath) {
+      return false;
+    }
+    if (appConfig.isTabBarPage(pagePath) || pagePath === appConfig.entryPagePath) {
+      return false;
+    }
+    const isStackBottom = app.navigatorManager.getPageCountForWebViewId(webViewId) <= 1;
+    return isStackBottom || this.navStyle.get('homeButton') === true;
+  }
+
   getTitleString(): string {
     DMPLogger.d("isStatusBarDarkMode getTitleString=", this.navStyle.get('navigationBarTitleText'));
     if (this.navStyle.get('navigationBarTitleText')) {

--- a/harmony/dimina/src/main/ets/DPages/DMPPageTitle.ets
+++ b/harmony/dimina/src/main/ets/DPages/DMPPageTitle.ets
@@ -4,6 +4,8 @@ import { DMPWindowUtil } from '../Utils/DMPWindowUtils'
 import { DMPPageRecord } from '../Navigator/DMPPageRecord'
 import { DMPAppManager } from '../DApp/DMPAppManager'
 import { DMPMenuButtonLayout } from '../Utils/DMPMenuButtonLayout'
+import { DMPLogger } from '../EventTrack/DMPLogger'
+import { Tags } from '../EventTrack/Tags'
 
 @Component
 export struct DMPPageTitle {
@@ -14,6 +16,11 @@ export struct DMPPageTitle {
   @Prop
   webViewId: number
   private readonly titleHorizontalInset: number = DMPMenuButtonLayout.titleHorizontalInset
+  // Material Icons 的 home 造型（与各端返回箭头同属 Material 图标体系），
+  // 原始 24×24 path 缩放到 55 触控区居中的 22px 视区（16.5px 内边距），叠在灰色圆形底上
+  // （见 build() 里的 Circle），对齐微信真机 home 图标的圆底+图标组合
+  private readonly homeIconCommands: string =
+    'M25.7 34.8 L25.7 29.3 L29.3 29.3 L29.3 34.8 L33.9 34.8 L33.9 27.5 L36.7 27.5 L27.5 19.3 L18.3 27.5 L21.1 27.5 L21.1 34.8 Z'
 
   aboutToAppear(): void {
 
@@ -35,21 +42,41 @@ export struct DMPPageTitle {
           .maxLines(1)
           .textOverflow({ overflow: TextOverflow.Ellipsis })
 
-        Image($r(this.getPageStyle(this.pageRecord)?.isStatusBarDarkMode() ? 'app.media.ic_dmp_back_black' :
-          'app.media.ic_dmp_back_white'))
-          .width(55)
-          .height(55)
-          .padding(15)
-          .position({ x: 0, y: 0 })
-          .onClick((event?: ClickEvent) => {
-            const embedController =
-              DMPAppManager.sharedInstance().getApp(this.appIndex)?.getWebController(this.webViewId)?.subController
-            if (embedController?.accessBackward()) {
-              embedController.backward()
-            } else {
-              DMPAppManager.sharedInstance().getApp(this.appIndex)?.navigatorManager.getCurNavigator()?.pop()
-            }
-          })
+        if (this.showBackButton()) {
+          Image($r(this.getPageStyle(this.pageRecord)?.isStatusBarDarkMode() ? 'app.media.ic_dmp_back_black' :
+            'app.media.ic_dmp_back_white'))
+            .width(55)
+            .height(55)
+            .padding(15)
+            .position({ x: 0, y: 0 })
+            .onClick((event?: ClickEvent) => {
+              const embedController =
+                DMPAppManager.sharedInstance().getApp(this.appIndex)?.getWebController(this.webViewId)?.subController
+              if (embedController?.accessBackward()) {
+                embedController.backward()
+              } else {
+                DMPAppManager.sharedInstance().getApp(this.appIndex)?.navigatorManager.getCurNavigator()?.pop()
+              }
+            })
+        }
+        // 返回首页按钮独立判定：homeButton: true 的内页与返回箭头并存
+        // （微信实测样式），此时让出左槽紧随箭头之后
+        if (this.showHomeButton()) {
+          // 微信真机 home 图标带灰色圆形底，比返回箭头更粗更显眼；圆底色随导航栏深浅切换。
+          // 返回箭头/home 两个 55vp 触控槽位自带留白（各自图标居中，槽位比图标本身大），
+          // 不再额外叠加槽位间距，否则视觉间距会远超微信原生
+          // `.navigator-hd a+a{margin-left:10px}` 的 10vp
+          Circle({ width: 55, height: 55 })
+            .padding(11.5)
+            .fill(this.getPageStyle(this.pageRecord)?.isStatusBarDarkMode() ? 'rgba(255,255,255,0.24)' : '#D6D6D6')
+            .position({ x: this.showBackButton() ? 55 : 0, y: 0 })
+          Path({ width: 55, height: 55, commands: this.homeIconCommands })
+            .fill(this.getPageStyle(this.pageRecord)?.getTitleTextColor() ?? '#000000')
+            .position({ x: this.showBackButton() ? 55 : 0, y: 0 })
+            .onClick(() => {
+              this.goHome()
+            })
+        }
       }
       .width('100%')
       .height(55)
@@ -65,5 +92,38 @@ export struct DMPPageTitle {
       return pageRecord.pageStyle
     }
     return undefined;
+  }
+
+  // 返回箭头显示判据：tabBar 页永不显示（tab 页经 tabBar 即可离开，微信亦无箭头）；
+  // 栈深 > 1 显示；栈底页面仅当嵌入 web-view（同层渲染）自身有可回退历史时保留箭头
+  // （点击优先回退嵌入历史，见 onClick）。读 pageRecord.embeddedCanGoBack 镜像而非直接
+  // 轮询 controller——镜像赋值本身就是标题栏的重建信号（见 EmbedWebView.syncEmbeddedHistoryState），
+  // 保证箭头随嵌入历史出现/消失。栈底箭头与返回首页按钮互斥，见 shouldShowHomeButton
+  private showBackButton(): boolean {
+    const app = DMPAppManager.sharedInstance().getApp(this.appIndex)
+    if (!app) {
+      return true // app 尚不可用时维持既有箭头展示，不误藏
+    }
+    const pageRecord = app.navigatorManager.getPageRecordById(this.webViewId)
+    const pagePath = pageRecord?.pagePath
+    if (pagePath && app.bundleManager.getJsAppModuleConfig()?.isTabBarPage(pagePath)) {
+      return false
+    }
+    if (app.navigatorManager.getPageCountForWebViewId(this.webViewId) > 1) {
+      return true
+    }
+    return pageRecord?.embeddedCanGoBack === true
+  }
+
+  private showHomeButton(): boolean {
+    return this.getPageStyle(this.pageRecord)?.shouldShowHomeButton(this.webViewId) ?? false
+  }
+
+  // 路由判定收敛在 DMPNavigator.navigateHome（switchTab / redirectTo 的选择），标题栏只发起
+  private goHome(): void {
+    const navigator = DMPAppManager.sharedInstance().getApp(this.appIndex)?.navigatorManager.getCurNavigator()
+    navigator?.navigateHome().catch((err: Error) => {
+      DMPLogger.e(Tags.NAVIGATOR, `navigateHome failed: ${err?.message ?? err}`)
+    })
   }
 }

--- a/harmony/dimina/src/main/ets/Navigator/DMPNavigator.ets
+++ b/harmony/dimina/src/main/ets/Navigator/DMPNavigator.ets
@@ -237,11 +237,19 @@ export class DMPNavigator {
       }
       for (let i = 0; i < delta; i++) {
         this.pageLifecycle.onUnload(this.app.currentWebViewId)
-        DRouter.getInstance().pop(animated)
-        // DNavigation.pop()
+        // 弹路由前先看账本顶部记录是否真的占了 NavPathStack 槽位（见
+        // DMPPageRecord.shouldPopRouter）；popPageRecord() 会立刻把它从账本弹掉，须先取
+        if (DMPPageRecord.shouldPopRouter(this._stacks.peek()?.ownsRouterEntry)) {
+          DRouter.getInstance().pop(animated)
+        }
         this.popPageRecord()
       }
-      //ReLaunch 模式下，如自定义页面或启动模式是Insert情况，会导致页面少回退一个，但是小程序页面必须要解绑
+      // ReLaunch 补弹分支：与上面的 shouldPopRouter 判据是两件独立的事，不要合并。
+      // DApp.reLaunchCurrentStack/reLaunchRootStack 在被清空的 navigator 本身以
+      // customLaunchPageCallBack/openType=Insert 启动时，会把传入的 delta 预先 -1，
+      // 让上面的循环少处理这最后一条记录；这里只把它从账本弹掉，不调用 DRouter.pop()——
+      // 该记录要么从未进入 NavPathStack（customLaunchPageCallBack），要么是靠 replace
+      // 复用下层已有槽位（Insert），两种情况都不需要（也不能）在此额外弹一次路由帧
       if (isReLaunch && this._stacks.size() > 0) {
         this.pageLifecycle.onUnload(this.app.currentWebViewId)
         this.popPageRecord()
@@ -274,7 +282,11 @@ export class DMPNavigator {
     const pageCount = this._stacks.size()
     for (let i = 0; i < pageCount; i++) {
       this.pageLifecycle.onUnload(this.app.currentWebViewId)
-      DRouter.getInstance().pop(animated)
+      // 同 pop()：customLaunchPageCallBack 挂载的记录从未占用 NavPathStack 槽位，
+      // 无条件 DRouter.pop() 会误弹宿主自己挂载的页面
+      if (DMPPageRecord.shouldPopRouter(this._stacks.peek()?.ownsRouterEntry)) {
+        DRouter.getInstance().pop(animated)
+      }
       this.popPageRecord()
     }
   }
@@ -338,8 +350,12 @@ export class DMPNavigator {
       // Unload lifecycle（非 tab 页面是真正销毁，应当走 onUnload 而不是 onHide）
       this.pageLifecycle.onUnload(topRecord.webViewId)
 
-      // Pop from actual Navigation stack
-      DRouter.getInstance().pop(false) // animated = false for batch operations
+      // 弹路由前先看这条记录是否真的占了 NavPathStack 槽位（见 pop() 里同一判据的
+      // 注释）；customLaunchPageCallBack 挂载的页面从未进入 DRouter，若在这里无脑
+      // pop 会误弹共享单例栈里一条不相关的原生路由
+      if (DMPPageRecord.shouldPopRouter(topRecord.ownsRouterEntry)) {
+        DRouter.getInstance().pop(false) // animated = false，批量操作不做转场动画
+      }
 
       // Remove from internal stack
       this._stacks.data.pop()
@@ -381,6 +397,7 @@ export class DMPNavigator {
     this.pageLifecycle.onHide(this.app.currentWebViewId)
     DMPLogger.d(Tags.LAUNCH, "notify page.onHide end");
     const pageRecord = this.preLoadPage(pagePath, params)
+    pageRecord.ownsRouterEntry = DMPPageRecord.computeOwnsRouterEntry(!!customLaunchPageCallBack)
 
     try {
       if (customLaunchPageCallBack) {

--- a/harmony/dimina/src/main/ets/Navigator/DMPNavigator.ets
+++ b/harmony/dimina/src/main/ets/Navigator/DMPNavigator.ets
@@ -129,6 +129,43 @@ export class DMPNavigator {
 
   }
 
+  /**
+   * 返回首页（导航栏 home 按钮的唯一路由入口），终态都是只剩首页：
+   * 首页是 tab 页走 switchTab（保留其它 tab 状态并露出 tabBar，自带清非 tab 栈）；
+   * 首页非 tab 且当前是栈底，redirectTo 原地替换；非栈底（homeButton: true
+   * 的内页）redirect 只会替换栈顶、栈底仍在，须 relaunch 清整栈
+   */
+  async navigateHome(stackId: number) {
+    const appConfig = this.app.bundleManager.getJsAppModuleConfig()
+    const entryPagePath = appConfig?.entryPagePath
+    if (!appConfig || !entryPagePath) {
+      return
+    }
+    const routerParam = new DMPMap({ query: new DMPMap(), pagePath: entryPagePath })
+    if (appConfig.isTabBarPage(entryPagePath)) {
+      // 冷启动直达非 tab 内页时，栈内没有任何 tabBar 页，switchTab 清栈后无处可切
+      // （会抛 no tabBar context）；此时没有已加载的 tab 状态可保留，清栈重启到
+      // tab 首页与 switchTab 终态等价
+      const tabBarPagePaths = appConfig.getTabBarPagePaths()
+      let hasTabInStack = false
+      for (let record of this._stacks.data) {
+        if (tabBarPagePaths.has(record.pagePath)) {
+          hasTabInStack = true
+          break
+        }
+      }
+      if (hasTabInStack) {
+        await this.switchTab(routerParam)
+      } else {
+        await this.relaunchTo(routerParam)
+      }
+    } else if (this.pageCount() <= 1) {
+      await this.redirectTo(stackId, routerParam)
+    } else {
+      await this.relaunchTo(routerParam)
+    }
+  }
+
   async redirectTo(stackId: number, params: DMPMap) {
     DMPLogger.d(Tags.NAVIGATOR, 'redirectTo')
     const pagePath: string = params.get('pagePath')

--- a/harmony/dimina/src/main/ets/Navigator/DMPNavigatorDelegate.ets
+++ b/harmony/dimina/src/main/ets/Navigator/DMPNavigatorDelegate.ets
@@ -39,6 +39,10 @@ export class DMPNavigatorDelegate {
     await this._navigator.redirectTo(this._id, params);
   }
 
+  async navigateHome() {
+    await this._navigator.navigateHome(this._id);
+  }
+
   async pop(delta: number = 1) {
     await this._navigator.pop(delta);
   }

--- a/harmony/dimina/src/main/ets/Navigator/DMPNavigatorManager.ets
+++ b/harmony/dimina/src/main/ets/Navigator/DMPNavigatorManager.ets
@@ -89,6 +89,17 @@ export class DMPNavigatorManager {
     return record;
   }
 
+  /**
+   * 返回 webViewId 所属 navigator 当前的页面栈深度（栈深 1 = 该 navigator 的栈底页面）。
+   * TabBar 页面不进入任何 navigator 的 _stacks（见 DMPNavigator.createPageRecordForTab），
+   * 它们的箭头/首页按钮由 DMPPageTitle 按 isTabBarPage 单独排除；其余找不到所属 navigator
+   * 的 webViewId 保守返回 >1，不误判为栈底。
+   */
+  getPageCountForWebViewId(webViewId: number): number {
+    const navigator = this.findNavigatorByWebViewId(webViewId)
+    return navigator ? navigator.getPageCount() : 2
+  }
+
   count() {
     return this._navigatorDelegateStack.size()
   }

--- a/harmony/dimina/src/main/ets/Navigator/DMPPageRecord.ets
+++ b/harmony/dimina/src/main/ets/Navigator/DMPPageRecord.ets
@@ -22,6 +22,10 @@ export class DMPPageRecord {
   adjustPosition: number = 0
   actionSheetController?: ActionSheetController;
   domReadyListeners: DomReadyListener[] = [];
+  // 同层嵌入 web-view 是否有可回退历史的镜像（EmbedWebView 导航事件同步；真相源是
+  // 嵌入 controller 的 accessBackward()）。作为 @State/@Observed 一层属性，赋值即触发
+  // 页面标题栏重建，使栈底页的返回箭头随嵌入历史出现/消失
+  embeddedCanGoBack: boolean = false
 
   constructor(webViewId: number, fromWebViewId: number, pagePath: string, appIndex: number,
     webViewNodeController: DMPWebViewNodeController) {

--- a/harmony/dimina/src/main/ets/Navigator/DMPPageRecord.ets
+++ b/harmony/dimina/src/main/ets/Navigator/DMPPageRecord.ets
@@ -26,6 +26,12 @@ export class DMPPageRecord {
   // 嵌入 controller 的 accessBackward()）。作为 @State/@Observed 一层属性，赋值即触发
   // 页面标题栏重建，使栈底页的返回箭头随嵌入历史出现/消失
   embeddedCanGoBack: boolean = false
+  // 这条记录是否在共享 NavPathStack（DRouter 单例内部持有的那一份原生栈，见 DRouter.ets）
+  // 里真正占用了一个槽位。经 DRouter push/replace 挂载的页面（DMPOpenType.NavigateTo /
+  // Insert）为 true；customLaunchPageCallBack 场景由宿主自行挂载页面、从未进入
+  // NavPathStack，为 false。unwind 一条记录时是否要对应调用 DRouter.pop() 只认这个字段
+  // （见 shouldPopRouter），不要在别处另起一套算术判断
+  ownsRouterEntry: boolean = true
 
   constructor(webViewId: number, fromWebViewId: number, pagePath: string, appIndex: number,
     webViewNodeController: DMPWebViewNodeController) {
@@ -34,5 +40,23 @@ export class DMPPageRecord {
     this.fromWebViewId = fromWebViewId;
     this.appIndex = appIndex;
     this.webViewNodeController = webViewNodeController;
+  }
+
+  /**
+   * openPage 用来决定新记录是否占用共享 NavPathStack 槽位：customLaunchPageCallBack 存在时
+   * 页面完全绕过 DRouter，由宿主自行挂载，从未占槽位
+   */
+  static computeOwnsRouterEntry(hasCustomLaunchPageCallBack: boolean): boolean {
+    return !hasCustomLaunchPageCallBack
+  }
+
+  /**
+   * 判断 unwind 一条页面记录时是否需要对应调用 DRouter.pop()：只有真正占了共享
+   * NavPathStack 槽位的记录才需要——customLaunchPageCallBack 挂载的页面对它调用
+   * DRouter.pop() 会误弹别的页面。DMPNavigator.pop()/closeAllPages() 共用这一个判据。
+   * 栈已空、拿不到记录时保守返回 true，与两处调用方原有行为一致
+   */
+  static shouldPopRouter(ownsRouterEntry: boolean | undefined): boolean {
+    return ownsRouterEntry !== false
   }
 }

--- a/harmony/dimina/src/main/ets/Render/SameLayer/EmbedWebView.ets
+++ b/harmony/dimina/src/main/ets/Render/SameLayer/EmbedWebView.ets
@@ -30,14 +30,15 @@ export struct EmbedWebView {
     new DMPWebViewController(this.webViewId, DMPAppManager.sharedInstance().getApp(this.appIndex)!)
 
   aboutToAppear(): void {
+    // aboutToAppear 发生在 build() 创建 Web 组件、webviewController 绑定组件之前——
+    // 此时调用 controller 方法（如 accessBackward）会抛 BusinessError 17100001。这里只做
+    // 不依赖 controller 绑定状态的账本登记；槽位易主后的镜像重采样挪到
+    // onControllerAttached（build() 里），那是 controller 方法开始可用的最早时点
     const render = DMPAppManager.sharedInstance().getApp(this.appIndex)?.render;
     const controller = render?.getController(this.parentWebViewId)
     if (render && controller) {
       controller.subController = this.webviewController
       render.controllerMap.set(this.webViewId, controller)
-      // 槽位易主即重采样镜像：新活跃实例通常尚无历史，立刻把上一任留下的
-      // 镜像值纠正过来，不等首个 onPageEnd
-      this.syncEmbeddedHistoryState()
     }
   }
 
@@ -97,6 +98,12 @@ export struct EmbedWebView {
           methodList: ["invoke"],
           asyncMethodList: ["publish"],
           controller: this.webviewController
+        })
+        .onControllerAttached(() => {
+          // controller 成功绑定到 Web 组件、其方法开始可用的最早时点（早于
+          // onPageBegin/onPageEnd）。新活跃实例通常尚无历史，这里立刻把上一任槽位持有者
+          // 留下的镜像值纠正过来，不等首个 onPageEnd
+          this.syncEmbeddedHistoryState()
         })
         .onPageBegin(() => {
           this.webviewController.initConfig() // 设置ua

--- a/harmony/dimina/src/main/ets/Render/SameLayer/EmbedWebView.ets
+++ b/harmony/dimina/src/main/ets/Render/SameLayer/EmbedWebView.ets
@@ -35,12 +35,48 @@ export struct EmbedWebView {
     if (render && controller) {
       controller.subController = this.webviewController
       render.controllerMap.set(this.webViewId, controller)
+      // 槽位易主即重采样镜像：新活跃实例通常尚无历史，立刻把上一任留下的
+      // 镜像值纠正过来，不等首个 onPageEnd
+      this.syncEmbeddedHistoryState()
     }
   }
 
   aboutToDisappear(): void {
-    const render = DMPAppManager.sharedInstance().getApp(this.appIndex)?.render;
-    render?.controllerMap.delete(this.webViewId)
+    const app = DMPAppManager.sharedInstance().getApp(this.appIndex)
+    app?.render?.controllerMap.delete(this.webViewId)
+    // 只有当前占据 subController 槽位（= 标题栏点击回退的目标）的实例卸载时才清镜像，
+    // 避免非活跃实例的卸载误清活跃实例的历史状态
+    if (this.isActiveEmbedController()) {
+      const record = app?.navigatorManager.getPageRecordById(this.parentWebViewId)
+      if (record && record.embeddedCanGoBack) {
+        record.embeddedCanGoBack = false
+      }
+    }
+  }
+
+  // 把嵌入 web-view 的可回退状态镜像到宿主页 pageRecord（@Observed 一层属性，
+  // 赋值触发标题栏重建），仅在状态变化时写入避免无谓重建。宿主页的嵌入回退
+  // 目标是单槽位 subController，镜像只接受该槽位当前持有者的写入——多个嵌入
+  // 实例并存时，非活跃实例的导航/卸载事件不会污染镜像
+  private syncEmbeddedHistoryState(): void {
+    if (!this.isActiveEmbedController()) {
+      return
+    }
+    const record =
+      DMPAppManager.sharedInstance().getApp(this.appIndex)?.navigatorManager.getPageRecordById(this.parentWebViewId)
+    if (!record) {
+      return
+    }
+    const canGoBack = this.webviewController.accessBackward()
+    if (record.embeddedCanGoBack !== canGoBack) {
+      record.embeddedCanGoBack = canGoBack
+    }
+  }
+
+  private isActiveEmbedController(): boolean {
+    const parentController =
+      DMPAppManager.sharedInstance().getApp(this.appIndex)?.getWebController(this.parentWebViewId)
+    return parentController?.subController === this.webviewController
   }
 
   build() {
@@ -66,6 +102,7 @@ export struct EmbedWebView {
           this.webviewController.initConfig() // 设置ua
         })
         .onPageEnd(() => {
+          this.syncEmbeddedHistoryState()
           const script = this.data.attributes?.javascript;
           const attrs = this.data.attributes?.attrs;
           const moduleId = this.data.attributes?.moduleId;

--- a/harmony/dimina/src/test/DMPPageRecordRouterOwnership.test.ets
+++ b/harmony/dimina/src/test/DMPPageRecordRouterOwnership.test.ets
@@ -1,0 +1,36 @@
+import { describe, it, expect } from '@ohos/hypium'
+import { DMPPageRecord } from '../main/ets/Navigator/DMPPageRecord'
+
+export default function dmpPageRecordRouterOwnershipTest() {
+  describe('DMPPageRecord.computeOwnsRouterEntry', () => {
+    it('doesNotOwnRouterEntryWhenCustomLaunchPageCallBackMountsThePage', 0, () => {
+      // customLaunchPageCallBack bypasses DRouter entirely, so the record never
+      // occupies a shared NavPathStack slot.
+      expect(DMPPageRecord.computeOwnsRouterEntry(true)).assertEqual(false)
+    })
+
+    it('ownsRouterEntryWhenDRouterMountsThePage', 0, () => {
+      // Without a custom launch callback, openPage mounts the page through
+      // DRouter push/replace, which does occupy a NavPathStack slot.
+      expect(DMPPageRecord.computeOwnsRouterEntry(false)).assertEqual(true)
+    })
+  })
+
+  describe('DMPPageRecord.shouldPopRouter', () => {
+    it('popsRouterWhenTheRecordOwnsANavPathStackSlot', 0, () => {
+      expect(DMPPageRecord.shouldPopRouter(true)).assertEqual(true)
+    })
+
+    it('skipsPopWhenTheRecordNeverOccupiedANavPathStackSlot', 0, () => {
+      // Calling DRouter.pop() for a page that never occupied a slot would
+      // pop an unrelated page instead.
+      expect(DMPPageRecord.shouldPopRouter(false)).assertEqual(false)
+    })
+
+    it('defaultsToPoppingWhenNoPageRecordIsAvailableToCheck', 0, () => {
+      // Conservative default matching the pre-existing behavior of both
+      // call sites when the stack is already empty and no record can be found.
+      expect(DMPPageRecord.shouldPopRouter(undefined)).assertEqual(true)
+    })
+  })
+}

--- a/harmony/dimina/src/test/List.test.ets
+++ b/harmony/dimina/src/test/List.test.ets
@@ -1,7 +1,9 @@
 import localUnitTest from './LocalUnit.test';
 import menuButtonGeometryTest from './MenuButtonGeometry.test';
+import dmpPageRecordRouterOwnershipTest from './DMPPageRecordRouterOwnership.test';
 
 export default function testsuite() {
   localUnitTest();
   menuButtonGeometryTest();
+  dmpPageRecordRouterOwnershipTest();
 }

--- a/iOS/dimina.xcodeproj/project.pbxproj
+++ b/iOS/dimina.xcodeproj/project.pbxproj
@@ -7,18 +7,35 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		14603AA5921BC560B952F3E9 /* DMPUtilPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DD3E623362F9D7264941CD /* DMPUtilPathTests.swift */; };
 		1A2B3C4D5E6F700000000001 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 1A2B3C4D5E6F700000000101 /* Alamofire */; };
 		1A2B3C4D5E6F700000000002 /* MMKV in Frameworks */ = {isa = PBXBuildFile; productRef = 1A2B3C4D5E6F700000000102 /* MMKV */; };
 		1A2B3C4D5E6F700000000003 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 1A2B3C4D5E6F700000000103 /* ZIPFoundation */; };
+		D3AF9DC58D4F29D8D2A8F71F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2EAA9C0614F7638987B22EAC /* Foundation.framework */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		425BDC30CA314D645195B564 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0A6F85D02DAE3D7D0047A006 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0A6F85D72DAE3D7D0047A006;
+			remoteInfo = dimina;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		0A6F85D82DAE3D7D0047A006 /* dimina.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = dimina.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		2EAA9C0614F7638987B22EAC /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		5D995E363EB06797E5E3DB0D /* diminaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = diminaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		61DD3E623362F9D7264941CD /* DMPUtilPathTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DMPUtilPathTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		0A6F85DA2DAE3D7D0047A006 /* dimina */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = dimina;
 			sourceTree = "<group>";
 		};
@@ -35,6 +52,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A9DECAB17F22C566C3183280 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D3AF9DC58D4F29D8D2A8F71F /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -43,6 +68,8 @@
 			children = (
 				0A6F85DA2DAE3D7D0047A006 /* dimina */,
 				0A6F85D92DAE3D7D0047A006 /* Products */,
+				E07F041A9E2897B4C9F7EE93 /* Frameworks */,
+				A25481309172EDD172D6037B /* diminaTests */,
 			);
 			sourceTree = "<group>";
 		};
@@ -50,8 +77,34 @@
 			isa = PBXGroup;
 			children = (
 				0A6F85D82DAE3D7D0047A006 /* dimina.app */,
+				5D995E363EB06797E5E3DB0D /* diminaTests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		A1A880FA1CE19FE5226DD6BF /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				2EAA9C0614F7638987B22EAC /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		A25481309172EDD172D6037B /* diminaTests */ = {
+			isa = PBXGroup;
+			children = (
+				61DD3E623362F9D7264941CD /* DMPUtilPathTests.swift */,
+			);
+			name = diminaTests;
+			path = diminaTests;
+			sourceTree = "<group>";
+		};
+		E07F041A9E2897B4C9F7EE93 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				A1A880FA1CE19FE5226DD6BF /* iOS */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -82,6 +135,24 @@
 			productName = dimina;
 			productReference = 0A6F85D82DAE3D7D0047A006 /* dimina.app */;
 			productType = "com.apple.product-type.application";
+		};
+		1117821FE0BE8D195C045561 /* diminaTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B2B2982469D8FB223BE46D4D /* Build configuration list for PBXNativeTarget "diminaTests" */;
+			buildPhases = (
+				4E8515AE7920D12C4879036D /* Sources */,
+				A9DECAB17F22C566C3183280 /* Frameworks */,
+				8686C926F6396745BC2C85D0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				21D2CF2ECD81EA695D26AD0F /* PBXTargetDependency */,
+			);
+			name = diminaTests;
+			productName = diminaTests;
+			productReference = 5D995E363EB06797E5E3DB0D /* diminaTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -118,12 +189,20 @@
 			projectRoot = "";
 			targets = (
 				0A6F85D72DAE3D7D0047A006 /* dimina */,
+				1117821FE0BE8D195C045561 /* diminaTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		0A6F85D62DAE3D7D0047A006 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8686C926F6396745BC2C85D0 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -163,7 +242,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4E8515AE7920D12C4879036D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				14603AA5921BC560B952F3E9 /* DMPUtilPathTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		21D2CF2ECD81EA695D26AD0F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = dimina;
+			target = 0A6F85D72DAE3D7D0047A006 /* dimina */;
+			targetProxy = 425BDC30CA314D645195B564 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		0A6F85E42DAE3D7F0047A006 /* Debug */ = {
@@ -363,6 +459,49 @@
 			};
 			name = Release;
 		};
+		410698C041695C27E7C612D8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGNING_ALLOWED[sdk=iphonesimulator*]" = NO;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.didi.dimina.diminaTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/dimina.app/dimina";
+			};
+			name = Debug;
+		};
+		BDBAD9C9F0C0C97BA6E50B44 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGNING_ALLOWED[sdk=iphonesimulator*]" = NO;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.didi.dimina.diminaTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/dimina.app/dimina";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -380,6 +519,15 @@
 			buildConfigurations = (
 				0A6F85E72DAE3D7F0047A006 /* Debug */,
 				0A6F85E82DAE3D7F0047A006 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B2B2982469D8FB223BE46D4D /* Build configuration list for PBXNativeTarget "diminaTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BDBAD9C9F0C0C97BA6E50B44 /* Release */,
+				410698C041695C27E7C612D8 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/iOS/dimina.xcodeproj/project.pbxproj
+++ b/iOS/dimina.xcodeproj/project.pbxproj
@@ -26,7 +26,7 @@
 
 /* Begin PBXFileReference section */
 		0A6F85D82DAE3D7D0047A006 /* dimina.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = dimina.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		2EAA9C0614F7638987B22EAC /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		2EAA9C0614F7638987B22EAC /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		5D995E363EB06797E5E3DB0D /* diminaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = diminaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		61DD3E623362F9D7264941CD /* DMPUtilPathTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DMPUtilPathTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */

--- a/iOS/dimina.xcodeproj/xcshareddata/xcschemes/dimina.xcscheme
+++ b/iOS/dimina.xcodeproj/xcshareddata/xcschemes/dimina.xcscheme
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0A6F85D72DAE3D7D0047A006"
+               BuildableName = "dimina.app"
+               BlueprintName = "dimina"
+               ReferencedContainer = "container:dimina.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1117821FE0BE8D195C045561"
+               BuildableName = "diminaTests.xctest"
+               BlueprintName = "diminaTests"
+               ReferencedContainer = "container:dimina.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0A6F85D72DAE3D7D0047A006"
+            BuildableName = "dimina.app"
+            BlueprintName = "dimina"
+            ReferencedContainer = "container:dimina.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1117821FE0BE8D195C045561"
+               BuildableName = "diminaTests.xctest"
+               BlueprintName = "diminaTests"
+               ReferencedContainer = "container:dimina.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0A6F85D72DAE3D7D0047A006"
+            BuildableName = "dimina.app"
+            BlueprintName = "dimina"
+            ReferencedContainer = "container:dimina.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0A6F85D72DAE3D7D0047A006"
+            BuildableName = "dimina.app"
+            BlueprintName = "dimina"
+            ReferencedContainer = "container:dimina.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/iOS/dimina/ContentView.swift
+++ b/iOS/dimina/ContentView.swift
@@ -14,6 +14,9 @@ struct ContentView: View {
     // 存储UINavigationController的引用
     static var navigationController: UINavigationController?
 
+    // 自动化测试钩子的一次性标记（见 autoOpenAppForTestIfRequested）
+    static var didAutoOpenForTest = false
+
     let appItems = DMPResourceManager.getDMPAppConfigs()
 
     var filteredItems: [DMPAppConfig] {
@@ -42,7 +45,11 @@ struct ContentView: View {
 
         // 启动小程序
         Task { @MainActor in
-            let launchConfig = DMPLaunchConfig()
+            // 自动化测试钩子：环境变量指定启动页（如验证非首页启动的返回首页按钮），
+            // 未设置时保持默认首页启动
+            let launchConfig = DMPLaunchConfig(
+                appEntryPath: ProcessInfo.processInfo.environment["DMP_TEST_ENTRY_PATH"]
+            )
             await app.launch(launchConfig: launchConfig)
         }
     }
@@ -96,7 +103,26 @@ struct ContentView: View {
             .navigationBarHidden(true)
             .onAppear {
                 setupNavigationController()
+                autoOpenAppForTestIfRequested()
             }
+        }
+    }
+
+    /// 自动化测试钩子：环境变量 DMP_TEST_AUTO_OPEN_APPID 指定 appId 时，启动后自动打开
+    /// 该小程序，配合 DMP_TEST_ENTRY_PATH 覆盖启动页。
+    /// 只触发一次：小程序 relaunch 的 popToRootViewController 会瞬时露出本列表页并
+    /// 重跑 onAppear，无防重会用测试入口页重启小程序、覆盖正在进行的 relaunch
+    private func autoOpenAppForTestIfRequested() {
+        guard !ContentView.didAutoOpenForTest,
+              let autoId = ProcessInfo.processInfo.environment["DMP_TEST_AUTO_OPEN_APPID"],
+              let item = appItems.first(where: { $0.id == autoId }) else {
+            return
+        }
+        ContentView.didAutoOpenForTest = true
+        // setupNavigationController 在 onAppear 中先向 main 队列入队；这里再入队
+        // 即按 FIFO 排在其后，执行时导航控制器已就绪，无需定时等待
+        DispatchQueue.main.async {
+            navigateToDetail(item: item)
         }
     }
 

--- a/iOS/dimina/DiminaKit/App/DMPApp.swift
+++ b/iOS/dimina/DiminaKit/App/DMPApp.swift
@@ -174,9 +174,10 @@ public class DMPApp {
         var newLaunchConfig = launchConfig
         // 尊重调用方指定的启动页（扫码/分享等场景从内页启动，此时导航栏按
         // 微信规则显示返回首页按钮）；未指定时回退到应用首页
-        // 路径入口统一去前导斜杠，与 DMPBundleAppConfig.entryPagePath 及页面栈 key 同口径
+        // 路径入口经 DMPUtil.normalizePagePath 统一去前导斜杠，与
+        // DMPBundleAppConfig.entryPagePath 及页面栈 key 同口径
         let requestedEntry = launchConfig.appEntryPath?.trimmingCharacters(in: .whitespaces) ?? ""
-        let normalizedEntry = String(requestedEntry.drop(while: { $0 == "/" }))
+        let normalizedEntry = DMPUtil.normalizePagePath(requestedEntry)
         newLaunchConfig.appEntryPath = normalizedEntry.isEmpty
             ? (self.bundleAppConfig?.entryPagePath ?? "")
             : normalizedEntry

--- a/iOS/dimina/DiminaKit/App/DMPApp.swift
+++ b/iOS/dimina/DiminaKit/App/DMPApp.swift
@@ -172,7 +172,14 @@ public class DMPApp {
     public func openPage(launchConfig: DMPLaunchConfig) async {
         DMPLogger.debug("openPage")
         var newLaunchConfig = launchConfig
-        newLaunchConfig.appEntryPath = self.bundleAppConfig?.entryPagePath ?? ""
+        // 尊重调用方指定的启动页（扫码/分享等场景从内页启动，此时导航栏按
+        // 微信规则显示返回首页按钮）；未指定时回退到应用首页
+        // 路径入口统一去前导斜杠，与 DMPBundleAppConfig.entryPagePath 及页面栈 key 同口径
+        let requestedEntry = launchConfig.appEntryPath?.trimmingCharacters(in: .whitespaces) ?? ""
+        let normalizedEntry = String(requestedEntry.drop(while: { $0 == "/" }))
+        newLaunchConfig.appEntryPath = normalizedEntry.isEmpty
+            ? (self.bundleAppConfig?.entryPagePath ?? "")
+            : normalizedEntry
         currentLaunchConfig = newLaunchConfig
         await navigator?.launch(to: newLaunchConfig.appEntryPath ?? "", query: newLaunchConfig.query)
     }

--- a/iOS/dimina/DiminaKit/Bundle/DMPBundleAppConfig.swift
+++ b/iOS/dimina/DiminaKit/Bundle/DMPBundleAppConfig.swift
@@ -72,7 +72,11 @@ public class DMPBundleAppConfig {
                 }
                 _entryPagePath = firstPage
             }
-            return _entryPagePath
+            // 统一输出无前导斜杠的 module-key 形态——首页判定（resolveLeftNavAction）、
+            // navigateHome、openPage 等所有读者都按 app-config key 消费同一权威值
+            return _entryPagePath.hasPrefix("/")
+                ? String(_entryPagePath.drop(while: { $0 == "/" }))
+                : _entryPagePath
         }
         set {
             _entryPagePath = newValue
@@ -92,8 +96,10 @@ public class DMPBundleAppConfig {
                        (appWindowConfig["navigationBarTextStyle"] as? String) ?? "black"
         mergedConfig["backgroundColor"] = (pagePrivateConfig["backgroundColor"] as? String) ?? 
                        (appWindowConfig["backgroundColor"] as? String) ?? "#FFFFFF"
-        mergedConfig["navigationStyle"] = (pagePrivateConfig["navigationStyle"] as? String) ?? 
+        mergedConfig["navigationStyle"] = (pagePrivateConfig["navigationStyle"] as? String) ??
                        (appWindowConfig["navigationStyle"] as? String) ?? "default"
+        mergedConfig["homeButton"] = (pagePrivateConfig["homeButton"] as? Bool) ??
+                       (appWindowConfig["homeButton"] as? Bool) ?? false
         mergedConfig["usingComponents"] = pagePrivateConfig["usingComponents"] ?? [:]
         
         return mergedConfig

--- a/iOS/dimina/DiminaKit/Container/Api/UI/NavigationBarAPI.swift
+++ b/iOS/dimina/DiminaKit/Container/Api/UI/NavigationBarAPI.swift
@@ -16,6 +16,7 @@ public class NavigationBarAPI: DMPContainerApi {
     // API method names
     private static let SET_NAVIGATION_BAR_TITLE = "setNavigationBarTitle"
     private static let SET_NAVIGATION_BAR_COLOR = "setNavigationBarColor"
+    private static let HIDE_HOME_BUTTON = "hideHomeButton"
     
     // Set navigation bar title
     @BridgeMethod(SET_NAVIGATION_BAR_TITLE)
@@ -155,6 +156,46 @@ public class NavigationBarAPI: DMPContainerApi {
             DMPContainerApi.invokeSuccess(callback: callback, param: result)
         }
         
+        return DMPAsyncResult()
+    }
+
+    // Hide the home button for the calling page (wx.hideHomeButton)
+    @BridgeMethod(HIDE_HOME_BUTTON)
+    var hideHomeButton: DMPBridgeMethodHandler = { param, env, callback in
+        let app = DMPAppManager.sharedInstance().getApp(appIndex: env.appIndex)
+
+        DispatchQueue.main.async {
+            // The flag lives on the caller's page record (keyed by env.webViewId),
+            // so a delayed call from a background page hides that page's own
+            // button — never the currently visible page's.
+            guard let pageRecord = app?.getNavigator()?.pageRecord(webViewId: env.webViewId) else {
+                let errorMsg = "\(HIDE_HOME_BUTTON):fail page not found"
+                DMPContainerApi.invokeFailure(callback: callback, param: nil, errMsg: errorMsg)
+                return
+            }
+            pageRecord.homeButtonForceHidden = true
+
+            // Refresh the on-screen nav bar only when the caller is the visible
+            // page; background pages re-derive it in viewWillAppear.
+            let topPageController: DMPPageController? = {
+                guard let top = app?.getNavigator()?.navigationController?.topViewController else {
+                    return nil
+                }
+                if let controller = top as? DMPPageController {
+                    return controller
+                }
+                if let tabBarController = top as? DMPTabBarContainerController {
+                    return tabBarController.currentPageController
+                }
+                return nil
+            }()
+            topPageController?.refreshNavigationBar(ifDisplaying: env.webViewId)
+
+            let result = DMPMap()
+            result.set("errMsg", "\(HIDE_HOME_BUTTON):ok")
+            DMPContainerApi.invokeSuccess(callback: callback, param: result)
+        }
+
         return DMPAsyncResult()
     }
 }

--- a/iOS/dimina/DiminaKit/Container/DMPPageController.swift
+++ b/iOS/dimina/DiminaKit/Container/DMPPageController.swift
@@ -32,6 +32,13 @@ public class DMPPageController: UIViewController {
     private var customNavigationContentView: UIView?
     private var customNavigationTitleLabel: UILabel?
     private var customNavigationBackButton: UIButton?
+    private var customNavigationHomeButton: UIButton?
+    // 微信真机 home 图标带灰色圆形底，比返回箭头更粗更显眼；颜色随导航栏深浅切换，见 updateCustomHomeButton
+    private var customNavigationHomeButtonBackground: UIView?
+    // home 键的两套水平位置：独占左槽（栈底自动规则）/ 紧随返回箭头之后
+    // （homeButton: true 的内页，微信实测两者并存），按 showBack 切换激活
+    private var homeButtonLeadingToEdge: NSLayoutConstraint?
+    private var homeButtonLeadingAfterBack: NSLayoutConstraint?
     private var customNavigationCapsuleView: UIView?
     private var customNavigationCapsuleMoreButton: UIButton?
     private var customNavigationCapsuleCloseButton: UIButton?
@@ -260,6 +267,16 @@ public class DMPPageController: UIViewController {
         backButton.translatesAutoresizingMaskIntoConstraints = false
         backButton.addTarget(self, action: #selector(customBackButtonTapped), for: .touchUpInside)
 
+        let homeButton = UIButton(type: .custom)
+        homeButton.translatesAutoresizingMaskIntoConstraints = false
+        homeButton.accessibilityLabel = "Home"
+        homeButton.addTarget(self, action: #selector(homeButtonTapped), for: .touchUpInside)
+
+        let homeButtonBackground = UIView()
+        homeButtonBackground.translatesAutoresizingMaskIntoConstraints = false
+        homeButtonBackground.isUserInteractionEnabled = false
+        homeButtonBackground.layer.cornerRadius = 16
+
         let titleLabel = UILabel()
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.textAlignment = .center
@@ -286,6 +303,8 @@ public class DMPPageController: UIViewController {
         view.addSubview(capsuleView)
         navigationBar.addSubview(contentView)
         contentView.addSubview(backButton)
+        contentView.addSubview(homeButtonBackground)
+        contentView.addSubview(homeButton)
         contentView.addSubview(titleLabel)
 
         NSLayoutConstraint.activate([
@@ -304,6 +323,15 @@ public class DMPPageController: UIViewController {
             backButton.widthAnchor.constraint(equalToConstant: 44),
             backButton.heightAnchor.constraint(equalToConstant: 44),
 
+            homeButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            homeButton.widthAnchor.constraint(equalToConstant: 44),
+            homeButton.heightAnchor.constraint(equalToConstant: 44),
+
+            homeButtonBackground.centerXAnchor.constraint(equalTo: homeButton.centerXAnchor),
+            homeButtonBackground.centerYAnchor.constraint(equalTo: homeButton.centerYAnchor),
+            homeButtonBackground.widthAnchor.constraint(equalToConstant: 32),
+            homeButtonBackground.heightAnchor.constraint(equalToConstant: 32),
+
             titleLabel.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
             titleLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: backButton.trailingAnchor, constant: 8),
@@ -318,9 +346,22 @@ public class DMPPageController: UIViewController {
             capsuleView.heightAnchor.constraint(equalToConstant: capsuleHeight),
         ])
 
+        let homeLeadingToEdge = homeButton.leadingAnchor.constraint(
+            equalTo: contentView.leadingAnchor, constant: 8)
+        // 44pt 触摸热区本身比图标大（图标 24pt 居中，热区两侧各留 10pt），
+        // 热区自带的留白已经提供了视觉间距，这里不再叠加额外 margin，
+        // 否则视觉间距会远超微信原生 `.navigator-hd a+a{margin-left:10px}` 的 10pt
+        let homeLeadingAfterBack = homeButton.leadingAnchor.constraint(
+            equalTo: backButton.trailingAnchor)
+        homeLeadingToEdge.isActive = true
+        homeButtonLeadingToEdge = homeLeadingToEdge
+        homeButtonLeadingAfterBack = homeLeadingAfterBack
+
         customNavigationBar = navigationBar
         customNavigationContentView = contentView
         customNavigationBackButton = backButton
+        customNavigationHomeButton = homeButton
+        customNavigationHomeButtonBackground = homeButtonBackground
         customNavigationTitleLabel = titleLabel
         customNavigationCapsuleView = capsuleView
     }
@@ -550,6 +591,7 @@ public class DMPPageController: UIViewController {
         customNavigationBar?.backgroundColor = backgroundColor
         customNavigationTitleLabel?.textColor = textColor
         updateCustomBackButton(darkStyle: darkStyle)
+        updateCustomHomeButton(darkStyle: darkStyle)
         updateCustomCapsuleButton(darkStyle: darkStyle)
     }
 
@@ -572,8 +614,41 @@ public class DMPPageController: UIViewController {
         backButton.setTitleColor(darkStyle ? .white : .black, for: .normal)
     }
 
+    private func updateCustomHomeButton(darkStyle: Bool) {
+        guard let homeButton = customNavigationHomeButton else {
+            return
+        }
+
+        // 微信真机 home 图标的灰色圆形底，颜色随导航栏深浅切换
+        customNavigationHomeButtonBackground?.backgroundColor = darkStyle
+            ? UIColor.white.withAlphaComponent(0.24)
+            : UIColor(red: 0.839, green: 0.839, blue: 0.839, alpha: 1)
+
+        // 与返回箭头同机制：按 darkStyle 选择 Material home 造型的 SVG 资产
+        if let bundle = DMPResourceManager.assetsBundle {
+            let imageName = darkStyle ? "home-dark" : "home-light"
+            if let image = UIImage(named: imageName, in: bundle, compatibleWith: nil) {
+                homeButton.setImage(image.withRenderingMode(.alwaysOriginal), for: .normal)
+                return
+            }
+        }
+
+        // 资产缺失时退回 SF Symbol 模板渲染
+        if let homeImage = UIImage(systemName: "house") {
+            homeButton.setImage(homeImage.withRenderingMode(.alwaysTemplate), for: .normal)
+        }
+        homeButton.tintColor = darkStyle ? .white : .black
+    }
+
     @objc private func customBackButtonTapped() {
         navigator?.handleBackButtonTapped()
+    }
+
+    // 路由判定收敛在 DMPNavigator.navigateHome（switchTab / redirectTo 的选择），按钮只发起
+    @objc private func homeButtonTapped() {
+        Task { @MainActor [weak self] in
+            await self?.navigator?.navigateHome()
+        }
     }
 
     private func updateCustomCapsuleButton(darkStyle: Bool) {
@@ -831,7 +906,8 @@ public class DMPPageController: UIViewController {
         navigationItem.hidesBackButton = true
         navigationItem.backButtonTitle = ""
 
-        let navStyle = navigator?.pageRecord(webViewId: webview.getWebViewId())?.navStyle
+        let pageRecord = navigator?.pageRecord(webViewId: webview.getWebViewId())
+        let navStyle = pageRecord?.navStyle
             ?? app?.getBundleAppConfig()?.getPageConfig(pagePath: pagePath)
         let darkStyle = (navStyle?["navigationBarTextStyle"] as? String) == "white"
         var title = appConfig.appName
@@ -891,6 +967,23 @@ public class DMPPageController: UIViewController {
         updateNavigationTitle(title)
         updateNavigationColor(backgroundColor: backgroundColor, textColor: textColor, darkStyle: darkStyle)
 
+        let leftNav = resolveLeftNavAffordances(
+            isCustomNavigationStyle: isCustomNavigationStyle,
+            homeButtonForceHidden: pageRecord?.homeButtonForceHidden ?? false,
+            homeButtonForcedByConfig: (navStyle?["homeButton"] as? Bool) == true
+        )
+        customNavigationBackButton?.isHidden = !leftNav.showBack
+        customNavigationHomeButton?.isHidden = !leftNav.showHome
+        customNavigationHomeButtonBackground?.isHidden = !leftNav.showHome
+        // home 键位置随返回箭头存在与否切换：并存时紧随箭头，否则独占左槽
+        if leftNav.showBack {
+            homeButtonLeadingToEdge?.isActive = false
+            homeButtonLeadingAfterBack?.isActive = true
+        } else {
+            homeButtonLeadingAfterBack?.isActive = false
+            homeButtonLeadingToEdge?.isActive = true
+        }
+
         customNavigationBar?.isHidden = isCustomNavigationStyle
         webViewTopToNavigationConstraint?.isActive = !isCustomNavigationStyle
         webViewTopToViewConstraint?.isActive = isCustomNavigationStyle
@@ -898,6 +991,59 @@ public class DMPPageController: UIViewController {
         if !isCustomNavigationStyle, let customNavigationBar = customNavigationBar {
             view.bringSubviewToFront(customNavigationBar)
         }
+    }
+
+    /// 导航栏左侧的两个 affordance（微信真机实测语义）：
+    /// 返回箭头 = 非栈底页面；home 键 = 非首页 + 非 tabBar 页（这两条排除
+    /// `homeButton: true` 也不能突破）且（栈底自动显示 ‖ 页面配置
+    /// `homeButton: true`——此时与返回箭头并存）。`wx.hideHomeButton()` 只压制
+    /// home 键。
+    private func resolveLeftNavAffordances(
+        isCustomNavigationStyle: Bool,
+        homeButtonForceHidden: Bool,
+        homeButtonForcedByConfig: Bool
+    ) -> (showBack: Bool, showHome: Bool) {
+        guard !isCustomNavigationStyle else {
+            return (false, false)
+        }
+
+        // isRoot means this page sits at the bottom of the stack (nothing to pop back to).
+        let showBack = !isRoot
+
+        if homeButtonForceHidden {
+            return (showBack, false)
+        }
+
+        guard let bundleAppConfig = app?.getBundleAppConfig() else {
+            return (showBack, false)
+        }
+
+        if bundleAppConfig.isTabBarPage(pagePath: pagePath) {
+            return (showBack, false)
+        }
+
+        // entryPagePath 由 DMPBundleAppConfig 统一输出规范形态（无前导斜杠），
+        // 只需归一化当前页一侧（pagePath 是页面构造参数，写法不受控）；
+        // entry 未知（空）时自动规则关闭
+        let entryPagePath = bundleAppConfig.entryPagePath
+        if entryPagePath.isEmpty || Self.normalizedPagePath(pagePath) == entryPagePath {
+            return (showBack, false)
+        }
+
+        return (showBack, isRoot || homeButtonForcedByConfig)
+    }
+
+    private static func normalizedPagePath(_ path: String) -> String {
+        path.hasPrefix("/") ? String(path.dropFirst()) : path
+    }
+
+    /// Re-derives the nav bar (including home-button visibility) when this
+    /// controller currently displays `webViewId`; a no-op for other pages —
+    /// their `viewWillAppear` re-runs `setupNavigationBar()` and picks up any
+    /// page-record flag set while they were in the background.
+    public func refreshNavigationBar(ifDisplaying webViewId: Int) {
+        guard webview.getWebViewId() == webViewId else { return }
+        setupNavigationBar()
     }
 
     // Back button tap event

--- a/iOS/dimina/DiminaKit/Container/DMPPageController.swift
+++ b/iOS/dimina/DiminaKit/Container/DMPPageController.swift
@@ -1007,7 +1007,7 @@ public class DMPPageController: UIViewController {
             return (false, false)
         }
 
-        // isRoot means this page sits at the bottom of the stack (nothing to pop back to).
+        // isRoot 表示这个页面在栈底（没有可以返回的上一页）
         let showBack = !isRoot
 
         if homeButtonForceHidden {
@@ -1023,24 +1023,22 @@ public class DMPPageController: UIViewController {
         }
 
         // entryPagePath 由 DMPBundleAppConfig 统一输出规范形态（无前导斜杠），
-        // 只需归一化当前页一侧（pagePath 是页面构造参数，写法不受控）；
-        // entry 未知（空）时自动规则关闭
+        // 只需归一化当前页一侧。pagePath 不保证已归一化：站内路由 URL
+        // （navigateTo/redirectTo/switchTab/reLaunch）经 DMPUtil.queryPath 已
+        // 归一化，但 tabBar 页的 pagePath 直接取自 tabBar 配置项
+        // （DMPTabBarContainerController 的 onSelect/prepareInitialTab），
+        // 未经 queryPath，写法不受调用方控制；entry 未知（空）时自动规则关闭
         let entryPagePath = bundleAppConfig.entryPagePath
-        if entryPagePath.isEmpty || Self.normalizedPagePath(pagePath) == entryPagePath {
+        if entryPagePath.isEmpty || DMPUtil.normalizePagePath(pagePath) == entryPagePath {
             return (showBack, false)
         }
 
         return (showBack, isRoot || homeButtonForcedByConfig)
     }
 
-    private static func normalizedPagePath(_ path: String) -> String {
-        path.hasPrefix("/") ? String(path.dropFirst()) : path
-    }
-
-    /// Re-derives the nav bar (including home-button visibility) when this
-    /// controller currently displays `webViewId`; a no-op for other pages —
-    /// their `viewWillAppear` re-runs `setupNavigationBar()` and picks up any
-    /// page-record flag set while they were in the background.
+    /// 仅当这个 controller 当前显示的正是 `webViewId` 时才重新计算导航栏（含
+    /// home 按钮显隐）；其它页面这里不做任何事——它们的 `viewWillAppear` 会
+    /// 重新跑一次 `setupNavigationBar()`，自然会读到后台期间被设置的页面标记
     public func refreshNavigationBar(ifDisplaying webViewId: Int) {
         guard webview.getWebViewId() == webViewId else { return }
         setupNavigationBar()

--- a/iOS/dimina/DiminaKit/Container/DMPTabBarContainerController.swift
+++ b/iOS/dimina/DiminaKit/Container/DMPTabBarContainerController.swift
@@ -135,6 +135,13 @@ final class DMPTabBarContainerController: UIViewController {
         return tabPageRecords[index]
     }
 
+    /// 按 webViewId 查找 tab 页记录（含未选中的后台 tab）。navigator 的
+    /// pageRecords 只镜像当前选中 tab，按调用页记账的 API（如 hideHomeButton）
+    /// 需要能定位到后台 tab 的记录
+    func pageRecord(webViewId: Int) -> DMPPageRecord? {
+        return tabPageRecords.values.first { $0.webViewId == webViewId }
+    }
+
     func setTabBarStyle(
         color: String?,
         selectedColor: String?,

--- a/iOS/dimina/DiminaKit/Navigator/DMPNavigator.swift
+++ b/iOS/dimina/DiminaKit/Navigator/DMPNavigator.swift
@@ -46,7 +46,13 @@ public class DMPNavigator: NSObject {
     }
 
     public func pageRecord(webViewId: Int) -> DMPPageRecord? {
-        return pageRecords.first(where: { $0.webViewId == webViewId })
+        if let record = pageRecords.first(where: { $0.webViewId == webViewId }) {
+            return record
+        }
+        // pageRecords 的根位置只镜像当前选中 tab（updateRootTabRecord），
+        // 后台 tab 的记录存在 tab 容器自己的 tabPageRecords 里——这里兜底查询，
+        // 否则后台 tab 的迟到调用（如 wx.hideHomeButton）会找不到自己的页面
+        return currentTabBarContainer()?.pageRecord(webViewId: webViewId)
     }
 
     private func isTabBarPage(_ pagePath: String) -> Bool {
@@ -286,6 +292,24 @@ public class DMPNavigator: NSObject {
         }
     }
 
+    /// 返回首页（导航栏 home 按钮的唯一路由入口），终态都是只剩首页：
+    /// 首页是 tab 页走 switchTab（保留其它 tab 状态并露出 tabBar，自带清非 tab 栈）；
+    /// 首页非 tab 且当前是栈底，redirectTo 原地替换；非栈底（`homeButton: true`
+    /// 的内页）redirect 只会替换栈顶、栈底仍在，须 relaunch 清整栈
+    @MainActor
+    public func navigateHome() async {
+        guard let entryPagePath = app?.getBundleAppConfig()?.entryPagePath, !entryPagePath.isEmpty else {
+            return
+        }
+        if isTabBarPage(entryPagePath) {
+            await switchTab(to: entryPagePath)
+        } else if pageRecords.count <= 1 {
+            await redirectTo(to: entryPagePath)
+        } else {
+            await relaunch(to: entryPagePath)
+        }
+    }
+
     @MainActor
     public func redirectTo(to path: String, query: [String: Any]? = nil) async {
         guard let navigationController = navigationController else {
@@ -300,6 +324,11 @@ public class DMPNavigator: NSObject {
         }
 
         let currentIndex = navigationController.viewControllers.count - 1
+
+        // 栈底判定与 navigateHome 同源：pageRecords 是小程序页面栈的唯一权威。
+        // 原生 viewControllers 的栈底可能是宿主自己的页面（如 demo 的应用列表），
+        // 按原生栈位置判栈底会把"替换仅剩的一页"误判为非栈底，导航栏因此错显返回箭头
+        let replacingStackBottom = pageRecords.count <= 1
 
         // 如果当前只有一个页面，则需要特殊处理
         if currentIndex == 0 {
@@ -348,7 +377,7 @@ public class DMPNavigator: NSObject {
             appConfig: app!.getAppConfig()!,
             app: app,
             navigator: self,
-            isRoot: false
+            isRoot: replacingStackBottom
         )
 
         let pageRecord = DMPPageRecord(

--- a/iOS/dimina/DiminaKit/Navigator/DMPPageRecord.swift
+++ b/iOS/dimina/DiminaKit/Navigator/DMPPageRecord.swift
@@ -11,6 +11,9 @@ public class DMPPageRecord {
     var pagePath: String
     var query: [String: Any]?
     var navStyle: [String: Any]?
+    /// Set by `wx.hideHomeButton()`; once true the home button stays hidden
+    /// for this page instance regardless of the default visibility rule.
+    var homeButtonForceHidden: Bool = false
 //    var pageStyle: DMPPageStyle?
 
     init(webViewId: Int, fromWebViewId: Int, pagePath: String) {

--- a/iOS/dimina/DiminaKit/Utils/DMPUtil.swift
+++ b/iOS/dimina/DiminaKit/Utils/DMPUtil.swift
@@ -46,17 +46,29 @@ public class DMPUtil {
         return try? JSONSerialization.jsonObject(with: data, options: []) as? [Any]
     }
 
+    /// 剥离路径前导斜杠，统一为无斜杠的 module-key 形态，
+    /// 与 DMPBundleAppConfig.entryPagePath / 页面栈 key 同口径
+    public static func normalizePagePath(_ path: String) -> String {
+        return String(path.drop(while: { $0 == "/" }))
+    }
+
+    /// 站内路由 URL（navigateTo/redirectTo/switchTab/reLaunch）唯一解析闸门：
+    /// pagePath 统一归一化，四个入口自动同口径，不需要各自补丁
     public static func queryPath(path: String) -> [String: Any] {
         let parts = path.components(separatedBy: "?")
-        let pagePath = parts[0]
+        let pagePath = normalizePagePath(parts[0])
         var paramsDict: [String: String] = [:]
 
-        if parts.count > 1, let paramStr = parts[1].components(separatedBy: "&").first {
+        if parts.count > 1 {
+            let paramStr = parts[1]
             for param in paramStr.components(separatedBy: "&") {
-                let keyValueArray = param.components(separatedBy: "=")
-                guard keyValueArray.count == 2 else { continue }
-                
-                let (key, value) = (keyValueArray[0], keyValueArray[1])
+                // 只按第一个 '=' 切分（对齐 Android Utils.kt split("=", limit=2) /
+                // Harmony DataTransformer.ets indexOf('=')）——value 本身含 '='
+                // （如 token/嵌套 URL）时不能被截断或整条丢弃
+                guard let equalsIndex = param.firstIndex(of: "=") else { continue }
+                let key = String(param[param.startIndex..<equalsIndex])
+                guard !key.isEmpty else { continue }
+                let value = String(param[param.index(after: equalsIndex)...])
                 paramsDict[key] = value
             }
         }

--- a/iOS/dimina/Resources/Assets.xcassets/home-dark.imageset/Contents.json
+++ b/iOS/dimina/Resources/Assets.xcassets/home-dark.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "home-dark.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iOS/dimina/Resources/Assets.xcassets/home-dark.imageset/home-dark.svg
+++ b/iOS/dimina/Resources/Assets.xcassets/home-dark.imageset/home-dark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" id="home">
+  <path fill="none" d="M0 0h24v24H0V0z"></path>
+  <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" fill="#ffffff"></path>
+</svg>

--- a/iOS/dimina/Resources/Assets.xcassets/home-light.imageset/Contents.json
+++ b/iOS/dimina/Resources/Assets.xcassets/home-light.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "home-light.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iOS/dimina/Resources/Assets.xcassets/home-light.imageset/home-light.svg
+++ b/iOS/dimina/Resources/Assets.xcassets/home-light.imageset/home-light.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" id="home">
+  <path fill="none" d="M0 0h24v24H0V0z"></path>
+  <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"></path>
+</svg>

--- a/iOS/diminaTests/DMPUtilPathTests.swift
+++ b/iOS/diminaTests/DMPUtilPathTests.swift
@@ -1,0 +1,87 @@
+//
+//  DMPUtilPathTests.swift
+//  diminaTests
+//
+
+import XCTest
+@testable import dimina
+
+final class DMPUtilPathTests: XCTestCase {
+
+    // MARK: - normalizePagePath
+
+    func testNormalizePagePath_stripsSingleLeadingSlash() {
+        XCTAssertEqual(DMPUtil.normalizePagePath("/pages/detail/index"), "pages/detail/index")
+    }
+
+    func testNormalizePagePath_stripsMultipleLeadingSlashes() {
+        XCTAssertEqual(DMPUtil.normalizePagePath("//pages/detail/index"), "pages/detail/index")
+    }
+
+    func testNormalizePagePath_leavesAlreadyNormalizedPathUnchanged() {
+        XCTAssertEqual(DMPUtil.normalizePagePath("pages/index/index"), "pages/index/index")
+    }
+
+    func testNormalizePagePath_emptyStringStaysEmpty() {
+        XCTAssertEqual(DMPUtil.normalizePagePath(""), "")
+    }
+
+    func testNormalizePagePath_singleSlashStripsToEmpty() {
+        XCTAssertEqual(DMPUtil.normalizePagePath("/"), "")
+    }
+
+    func testNormalizePagePath_doesNotTouchTrailingSlash() {
+        XCTAssertEqual(DMPUtil.normalizePagePath("pages/a/b/"), "pages/a/b/")
+    }
+
+    // MARK: - queryPath
+
+    func testQueryPath_normalizesLeadingSlashAndParsesQuery() {
+        let result = DMPUtil.queryPath(path: "/pages/detail/index?id=1&name=foo")
+
+        XCTAssertEqual(result["pagePath"] as? String, "pages/detail/index")
+        XCTAssertEqual(result["query"] as? [String: String], ["id": "1", "name": "foo"])
+    }
+
+    func testQueryPath_noLeadingSlashNoQuery() {
+        let result = DMPUtil.queryPath(path: "pages/index/index")
+
+        XCTAssertEqual(result["pagePath"] as? String, "pages/index/index")
+        XCTAssertEqual(result["query"] as? [String: String], [:])
+    }
+
+    func testQueryPath_trailingQuestionMarkWithNoQueryYieldsEmptyQuery() {
+        let result = DMPUtil.queryPath(path: "/pages/index/index?")
+
+        XCTAssertEqual(result["pagePath"] as? String, "pages/index/index")
+        XCTAssertEqual(result["query"] as? [String: String], [:])
+    }
+
+    func testQueryPath_multipleLeadingSlashesStripped() {
+        let result = DMPUtil.queryPath(path: "//pages/a/b?x=1")
+
+        XCTAssertEqual(result["pagePath"] as? String, "pages/a/b")
+        XCTAssertEqual(result["query"] as? [String: String], ["x": "1"])
+    }
+
+    func testQueryPath_valueContainingEqualsSignIsKeptWhole() {
+        // Splits on the FIRST '=' only, matching Android Utils.kt (split("=", limit=2))
+        // and Harmony DataTransformer.ets (indexOf('=')) — a value like a JWT or a
+        // re-encoded nested URL commonly contains '='.
+        let result = DMPUtil.queryPath(path: "pages/detail/index?token=a=b")
+
+        XCTAssertEqual(result["query"] as? [String: String], ["token": "a=b"])
+    }
+
+    func testQueryPath_paramWithNoEqualsSignIsDropped() {
+        let result = DMPUtil.queryPath(path: "pages/detail/index?flag&id=1")
+
+        XCTAssertEqual(result["query"] as? [String: String], ["id": "1"])
+    }
+
+    func testQueryPath_emptyKeyIsDropped() {
+        let result = DMPUtil.queryPath(path: "pages/detail/index?=orphaned&id=1")
+
+        XCTAssertEqual(result["query"] as? [String: String], ["id": "1"])
+    }
+}


### PR DESCRIPTION
在 Android、iOS、HarmonyOS、fe web 容器四端实现微信小程序「返回首页」导航按钮，语义与微信真机实测行为对齐。

## 显示条件

home 按钮只在默认导航栏下出现（`navigationStyle` 非 `custom`），并且当前页既不是 tabBar 页、也不是应用首页（`entryPagePath`）本身。在满足这两个前提之后，再满足下面任一条件就显示：

- 当前页是页面栈的栈底
- 当前页配置了 `homeButton: true`（此时与返回箭头**同时显示**——这是微信真机实测的真实行为）

页面可以调用 `wx.hideHomeButton` 单独隐藏当前页的 home 按钮。

## 点击行为

点击 home 按钮的最终结果永远是"只剩首页"，具体走哪条路径由当前状态决定：

- 首页本身是 tabBar 页 → 走 `switchTab`（保留其它 tab 各自的状态，不销毁重建）
- 首页不是 tabBar 页，且当前页已经是栈底 → 原地 `redirectTo` 替换当前页
- 其余情况（比如 `homeButton: true` 的内页，当前页并非栈底）→ `reLaunch`，清空整个页面栈后重新进入首页

## 各端补充修复

- **Android**：新增 `MiniProgramActivityRegistry` 账本类。所有页面复用同一个 Activity 类，OS 级 `CLEAR_TOP` 组件查找分不清哪个实例是当前活动页；`closeAllExcept` 现在按账本精确区分要保留的 Activity 和需要批量关闭的其它实例，而不是依赖系统的模糊查找。
- **HarmonyOS**：
  - 补上冷启动直接进入非 tabBar 内页时的兜底——这种情况下页面栈里还没有任何 tabBar 页，`switchTab` 无栈可切；改为回退到 `reLaunch`，效果等价（清栈后重新进入首页）。
  - `DMPNavigator.switchTab()` 清理非 tabBar 页面的循环里漏加了 `ownsRouterEntry`/`shouldPopRouter` 判据（`pop()`、`closeAllPages()` 两处已有），导致通过 `customLaunchPageCallBack` 挂载、从未真正进入共享 `NavPathStack` 的页面会被误弹一次不相关的原生路由。现在三处调用点判据一致。
  - `EmbedWebView` 的历史状态重采样（`syncEmbeddedHistoryState`）原来挂在 `aboutToAppear`，此时 Web 组件与 controller 尚未绑定，调用 controller 方法会抛 `BusinessError 17100001`；改到 `onControllerAttached`（controller 真正可用的最早时点）。
- **iOS**：
  - `redirectTo` 里判断是否为栈底页的 `isRoot` 标记此前被硬编码为 `false`，导致返回箭头不管实际是否在栈底都会常显；这次改成如实反映真实栈底状态，使返回箭头与 home 按钮的显隐逻辑保持一致（属于本次改动顺带修复的既有 bug，不是新引入的行为）。
  - `DMPUtil.queryPath` 的多参数解析原来没有处理 value 本身含 `=`（如 token、嵌套 URL）的情况，会把这类参数整条丢弃；改为只按第一个 `=` 切分（对齐 Android `Utils.kt`/HarmonyOS `DataTransformer.ets` 的语义），并补充空 key 时丢弃参数的兜底。
  - 新增 XCTest 单元测试 target（项目此前没有 iOS 单测基建），覆盖 `DMPUtil` 的路径归一化与 query 解析。

## 验证

**Android 真机**

- 全局强制 homeButton（`window.homeButton: true`）直启内页：home 按钮按栈底自动规则显示
- 点击 home 按钮原地落首页，无二次启动屏（redirectTo 路径）
- 首页与 tabBar 页本身不显示 home 按钮（forced 配置不能突破这两条排除规则）
- `homeButton: true` 的内页与返回箭头并存显示
- 非栈底内页（forced homeButton）点击 home 触发 reLaunch，清空整个页面栈
- tabBar 场景：tab 首页、非首页 tab 均正确不显示 home 按钮
- navigateTo 进入的内页与 home 按钮正确并存
- switchTab 分支路由分发正确（该分支触达了一个与本次改动无关的既有 WebView 池崩溃问题，已从本 PR 中排除，会另行反馈）
- `MiniProgramActivityRegistryTest` 单元测试绿

**iOS 模拟器**

- 直启内页仅显示 home 按钮（无返回箭头）
- navigateTo 进入内页，home 按钮与返回箭头正确并存
- tabBar 场景三个子场景（含 switchTab 后正确保留其它 tab 状态）
- redirectTo 落回首页后正确隐藏返回箭头（对应本 PR 里 `isRoot` 标记的修复）
- reLaunch 落回首页后正确停在首页，而非中途页（验证清栈逻辑）
- 新增的 `DMPUtilPathTests` XCTest 套件（13 条用例，含多 `=` value / 空 key 边界用例）全绿

**HarmonyOS 模拟器**

- tabBar 根页（组件/接口两个 tab）均正确不显示 home/back
- navigateTo 进入内页（深度 1-3）均只显示返回箭头，不显示 home
- 连续两次返回箭头正确回落 tabBar 根页
- redirectTo 落地后正确显示返回箭头
- `switchTab()` 真机 hilog 验证内部状态：`ownsRouterEntry=true → willPopRouter=true → poppedCount=1, stackLen 2→1`，清栈判据在真实页面栈上按预期生效
