### PR TITLE
ci: add iOS unit test workflow

### DIFF
--- a/.github/workflows/android-tests.yml
+++ b/.github/workflows/android-tests.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   unit-test:
-    name: Unit Tests
+    name: Android Unit Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   unit-test:
-    name: Unit Tests
+    name: iOS Unit Tests
     runs-on: macos-15
     timeout-minutes: 30
 

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -1,0 +1,64 @@
+name: iOS Tests
+
+on:
+  push:
+    paths: ['iOS/**', 'shared/**', '.github/workflows/ios-tests.yml']
+  pull_request:
+    paths: ['iOS/**', 'shared/**', '.github/workflows/ios-tests.yml']
+  workflow_dispatch:
+
+jobs:
+  unit-test:
+    name: Unit Tests
+    runs-on: macos-15
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Cache Swift Package Manager dependencies
+        uses: actions/cache@v4
+        with:
+          path: iOS/SourcePackages
+          key: ${{ runner.os }}-spm-${{ hashFiles('iOS/dimina.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
+      - name: Resolve Swift Package dependencies
+        working-directory: ./iOS
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project dimina.xcodeproj \
+            -scheme dimina \
+            -clonedSourcePackagesDirPath SourcePackages
+
+      - name: Run unit tests
+        working-directory: ./iOS
+        run: |
+          xcodebuild test \
+            -project dimina.xcodeproj \
+            -scheme dimina \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -clonedSourcePackagesDirPath SourcePackages \
+            -disableAutomaticPackageResolution \
+            -resultBundlePath TestResults.xcresult
+
+      - name: Compress test results
+        if: always()
+        working-directory: ./iOS
+        run: test -d TestResults.xcresult && zip -qr TestResults.xcresult.zip TestResults.xcresult || true
+
+      - name: Upload unit test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-unit-test-reports
+          path: ./iOS/TestResults.xcresult.zip
+          retention-days: 5
+          if-no-files-found: ignore


### PR DESCRIPTION
iOS 端目前没有 CI 测试覆盖（Android/fe 都有），新增 `ios-tests.yml`，
风格与现有 `android-tests.yml`/`fe-tests.yml` 保持一致：按 `paths` 触发 +
`workflow_dispatch`，跑 `diminaTests` 这个 XCTest target，失败/成功都上传
测试报告 artifact。

## 验证

- 本地 `xcodebuild test` 跑通，13 个用例全绿
- 在真实 GitHub-hosted macOS runner（macos-15）上验证两轮（改动前后各一次），
  均 13/13 通过，单次约 7 分钟
- SPM 依赖缓存路径显式指定，测试阶段加 `-disableAutomaticPackageResolution`
  确保用的是 `Package.resolved` 锁定的版本，而不是缓存命中与否导致行为漂移
- 触发路径覆盖 `iOS/**`、`shared/**`（iOS 构建通过 `copy-shared-resources.sh`
  依赖这个目录）和 workflow 文件自身