### PR TITLE
fix(fe,component): stop non-animated scroll from riding CSS scroll-behavior

### DIFF
--- a/fe/packages/components/__tests__/scroll-view-scroll-behavior.spec.js
+++ b/fe/packages/components/__tests__/scroll-view-scroll-behavior.spec.js
@@ -152,4 +152,38 @@ describe('ScrollView programmatic scroll behavior', () => {
 		expect(scrollToSpy).toHaveBeenCalledTimes(1)
 		expect(scrollToSpy).toHaveBeenCalledWith({ top: 88, left: 40, behavior: 'instant' })
 	})
+
+	it('cancels a pull-to-refresh gesture once the container has moved away from the top mid-touch', () => {
+		// A smooth initial/programmatic scroll can still be animating away from
+		// the top when touchstart samples scrollTop<=0. touchstart happens while
+		// the container still reads scrollTop 0 (the sentinel default); the
+		// animation is simulated to progress by the time touchmove fires.
+		window.__message = { send: vi.fn() }
+
+		const { element } = mountScrollView(() => ({
+			scrollY: true,
+			refresherEnabled: true,
+			bindrefresherpulling: 'onPulling',
+			bindrefresherrefresh: 'onRefresh',
+		}))
+
+		const touchStart = new Event('touchstart')
+		Object.defineProperty(touchStart, 'touches', { value: [{ clientY: 100 }] })
+		element.dispatchEvent(touchStart)
+
+		element.scrollTop = 50
+
+		const touchMove = new Event('touchmove')
+		Object.defineProperty(touchMove, 'touches', { value: [{ clientY: 300 }] })
+		element.dispatchEvent(touchMove)
+
+		const touchEnd = new Event('touchend')
+		Object.defineProperty(touchEnd, 'touches', { value: [] })
+		Object.defineProperty(touchEnd, 'changedTouches', { value: [] })
+		element.dispatchEvent(touchEnd)
+
+		const methodNames = window.__message.send.mock.calls.map(([message]) => message.body.methodName)
+		expect(methodNames).not.toContain('onPulling')
+		expect(methodNames).not.toContain('onRefresh')
+	})
 })

--- a/fe/packages/components/__tests__/scroll-view-scroll-behavior.spec.js
+++ b/fe/packages/components/__tests__/scroll-view-scroll-behavior.spec.js
@@ -1,0 +1,53 @@
+/** @vitest-environment jsdom */
+
+import { createApp, h, nextTick, provide, ref } from 'vue'
+import ScrollView from '../src/component/scroll-view/ScrollView.vue'
+
+function mountScrollView(getProps) {
+	const host = document.createElement('div')
+	document.body.appendChild(host)
+	const app = createApp({
+		setup() {
+			provide('bridgeId', 'bridge-1')
+			provide('path', 'page-path')
+			provide('page-path', { id: 'module-1' })
+			return () => h(ScrollView, getProps())
+		},
+	})
+	app.mount(host)
+	const element = host.querySelector('.dd-scroll-view')
+	// jsdom does not implement Element#scrollTo; stub it so scrollTo calls
+	// resolve instead of throwing, and so vi.spyOn has a property to wrap.
+	element.scrollTo = () => {}
+	return { app, host, element }
+}
+
+describe('ScrollView programmatic scroll behavior', () => {
+	it('jumps instantly instead of animating when scroll-with-animation is not enabled', async () => {
+		const scrollTop = ref(0)
+		const { app, host, element } = mountScrollView(() => ({ scrollY: true, scrollTop: scrollTop.value }))
+		const scrollToSpy = vi.spyOn(element, 'scrollTo')
+
+		scrollTop.value = 500
+		await nextTick()
+
+		expect(scrollToSpy).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'instant' }))
+
+		app.unmount()
+		host.remove()
+	})
+
+	it('animates when scroll-with-animation is explicitly enabled', async () => {
+		const scrollTop = ref(0)
+		const { app, host, element } = mountScrollView(() => ({ scrollY: true, scrollWithAnimation: true, scrollTop: scrollTop.value }))
+		const scrollToSpy = vi.spyOn(element, 'scrollTo')
+
+		scrollTop.value = 500
+		await nextTick()
+
+		expect(scrollToSpy).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'smooth' }))
+
+		app.unmount()
+		host.remove()
+	})
+})

--- a/fe/packages/components/__tests__/scroll-view-scroll-behavior.spec.js
+++ b/fe/packages/components/__tests__/scroll-view-scroll-behavior.spec.js
@@ -186,4 +186,42 @@ describe('ScrollView programmatic scroll behavior', () => {
 		expect(methodNames).not.toContain('onPulling')
 		expect(methodNames).not.toContain('onRefresh')
 	})
+
+	it('aborts an already-started refresher gesture once the container leaves the top', () => {
+		window.__message = { send: vi.fn() }
+
+		const { element } = mountScrollView(() => ({
+			scrollY: true,
+			refresherEnabled: true,
+			bindrefresherpulling: 'onPulling',
+			bindrefresherrefresh: 'onRefresh',
+			bindrefresherabort: 'onAbort',
+		}))
+
+		const touchStart = new Event('touchstart')
+		Object.defineProperty(touchStart, 'touches', { value: [{ clientY: 100 }] })
+		element.dispatchEvent(touchStart)
+
+		// still at the top: this move is a legitimate pull, so onPulling fires
+		const firstMove = new Event('touchmove')
+		Object.defineProperty(firstMove, 'touches', { value: [{ clientY: 150 }] })
+		element.dispatchEvent(firstMove)
+
+		// the container has since scrolled away from the top mid-gesture
+		element.scrollTop = 50
+
+		const secondMove = new Event('touchmove')
+		Object.defineProperty(secondMove, 'touches', { value: [{ clientY: 200 }] })
+		element.dispatchEvent(secondMove)
+
+		const touchEnd = new Event('touchend')
+		Object.defineProperty(touchEnd, 'touches', { value: [] })
+		Object.defineProperty(touchEnd, 'changedTouches', { value: [] })
+		element.dispatchEvent(touchEnd)
+
+		const methodNames = window.__message.send.mock.calls.map(([message]) => message.body.methodName)
+		expect(methodNames).toContain('onPulling')
+		expect(methodNames.filter(name => name === 'onAbort')).toHaveLength(1)
+		expect(methodNames).not.toContain('onRefresh')
+	})
 })

--- a/fe/packages/components/__tests__/scroll-view-scroll-behavior.spec.js
+++ b/fe/packages/components/__tests__/scroll-view-scroll-behavior.spec.js
@@ -3,7 +3,37 @@
 import { createApp, h, nextTick, provide, ref } from 'vue'
 import ScrollView from '../src/component/scroll-view/ScrollView.vue'
 
-function mountScrollView(getProps) {
+// jsdom does not implement Element#scrollTo. Stub it on the prototype before
+// mounting so the onMounted initial-position call (which now goes through
+// scrollTo instead of a direct property write) has something to call, and so
+// the spy also captures that mount-time call.
+const originalScrollTo = Object.getOwnPropertyDescriptor(Element.prototype, 'scrollTo')
+const originalScrollTop = Object.getOwnPropertyDescriptor(Element.prototype, 'scrollTop')
+const originalScrollLeft = Object.getOwnPropertyDescriptor(Element.prototype, 'scrollLeft')
+
+const mounted = []
+
+// currentScrollTop/currentScrollLeft let a test set a non-zero "already
+// scrolled to" sentinel so the fallback branch (axis not set by props) can be
+// asserted to read the element's current position rather than hardcoding 0.
+function mountScrollView(getProps, { currentScrollTop = 0, currentScrollLeft = 0 } = {}) {
+	const scrollToSpy = vi.fn()
+	Object.defineProperty(Element.prototype, 'scrollTo', {
+		configurable: true,
+		writable: true,
+		value: scrollToSpy,
+	})
+	Object.defineProperty(Element.prototype, 'scrollTop', {
+		configurable: true,
+		writable: true,
+		value: currentScrollTop,
+	})
+	Object.defineProperty(Element.prototype, 'scrollLeft', {
+		configurable: true,
+		writable: true,
+		value: currentScrollLeft,
+	})
+
 	const host = document.createElement('div')
 	document.body.appendChild(host)
 	const app = createApp({
@@ -14,40 +44,112 @@ function mountScrollView(getProps) {
 			return () => h(ScrollView, getProps())
 		},
 	})
+	mounted.push({ app, host })
 	app.mount(host)
 	const element = host.querySelector('.dd-scroll-view')
-	// jsdom does not implement Element#scrollTo; stub it so scrollTo calls
-	// resolve instead of throwing, and so vi.spyOn has a property to wrap.
-	element.scrollTo = () => {}
-	return { app, host, element }
+	return { app, host, element, scrollToSpy }
 }
+
+afterEach(() => {
+	let firstCleanupError
+	for (const { app, host } of mounted.splice(0)) {
+		try {
+			app.unmount()
+		}
+		catch (error) {
+			firstCleanupError ??= error
+		}
+		try {
+			host.remove()
+		}
+		catch (error) {
+			firstCleanupError ??= error
+		}
+	}
+
+	for (const [prop, original] of [['scrollTo', originalScrollTo], ['scrollTop', originalScrollTop], ['scrollLeft', originalScrollLeft]]) {
+		if (original) {
+			Object.defineProperty(Element.prototype, prop, original)
+		}
+		else {
+			delete Element.prototype[prop]
+		}
+	}
+
+	if (firstCleanupError) throw firstCleanupError instanceof Error ? firstCleanupError : new Error(String(firstCleanupError))
+})
 
 describe('ScrollView programmatic scroll behavior', () => {
 	it('jumps instantly instead of animating when scroll-with-animation is not enabled', async () => {
 		const scrollTop = ref(0)
-		const { app, host, element } = mountScrollView(() => ({ scrollY: true, scrollTop: scrollTop.value }))
-		const scrollToSpy = vi.spyOn(element, 'scrollTo')
+		const { scrollToSpy } = mountScrollView(() => ({ scrollY: true, scrollTop: scrollTop.value }))
+		scrollToSpy.mockClear()
 
 		scrollTop.value = 500
 		await nextTick()
 
 		expect(scrollToSpy).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'instant' }))
-
-		app.unmount()
-		host.remove()
 	})
 
 	it('animates when scroll-with-animation is explicitly enabled', async () => {
 		const scrollTop = ref(0)
-		const { app, host, element } = mountScrollView(() => ({ scrollY: true, scrollWithAnimation: true, scrollTop: scrollTop.value }))
-		const scrollToSpy = vi.spyOn(element, 'scrollTo')
+		const { scrollToSpy } = mountScrollView(() => ({ scrollY: true, scrollWithAnimation: true, scrollTop: scrollTop.value }))
+		scrollToSpy.mockClear()
 
 		scrollTop.value = 500
 		await nextTick()
 
 		expect(scrollToSpy).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'smooth' }))
+	})
 
-		app.unmount()
-		host.remove()
+	it('jumps instantly to the initial scroll position on mount when scroll-with-animation is not enabled', () => {
+		const { scrollToSpy } = mountScrollView(() => ({
+			scrollX: true,
+			scrollY: true,
+			scrollTop: 120,
+			scrollLeft: 40,
+		}))
+
+		expect(scrollToSpy).toHaveBeenCalledTimes(1)
+		expect(scrollToSpy).toHaveBeenCalledWith({ top: 120, left: 40, behavior: 'instant' })
+	})
+
+	it('animates to the initial scroll position on mount when scroll-with-animation is enabled', () => {
+		const { scrollToSpy } = mountScrollView(() => ({
+			scrollX: true,
+			scrollY: true,
+			scrollTop: 120,
+			scrollLeft: 40,
+			scrollWithAnimation: true,
+		}))
+
+		expect(scrollToSpy).toHaveBeenCalledTimes(1)
+		expect(scrollToSpy).toHaveBeenCalledWith({ top: 120, left: 40, behavior: 'smooth' })
+	})
+
+	it('does not call scrollTo on mount when neither scroll-top nor scroll-left is set', () => {
+		const { scrollToSpy } = mountScrollView(() => ({ scrollX: true, scrollY: true }))
+
+		expect(scrollToSpy).not.toHaveBeenCalled()
+	})
+
+	it('keeps the current scroll-left when only scroll-top is set on mount', () => {
+		const { scrollToSpy } = mountScrollView(
+			() => ({ scrollY: true, scrollTop: 120 }),
+			{ currentScrollLeft: 77 },
+		)
+
+		expect(scrollToSpy).toHaveBeenCalledTimes(1)
+		expect(scrollToSpy).toHaveBeenCalledWith({ top: 120, left: 77, behavior: 'instant' })
+	})
+
+	it('keeps the current scroll-top when only scroll-left is set on mount', () => {
+		const { scrollToSpy } = mountScrollView(
+			() => ({ scrollX: true, scrollLeft: 40 }),
+			{ currentScrollTop: 88 },
+		)
+
+		expect(scrollToSpy).toHaveBeenCalledTimes(1)
+		expect(scrollToSpy).toHaveBeenCalledWith({ top: 88, left: 40, behavior: 'instant' })
 	})
 })

--- a/fe/packages/components/src/component/scroll-view/ScrollView.vue
+++ b/fe/packages/components/src/component/scroll-view/ScrollView.vue
@@ -393,8 +393,13 @@ watch(() => props.scrollIntoView, scrollToChild, { flush: 'post' })
 onMounted(() => {
 	// 初始化滚动位置
 	if (scrollView.value) {
-		if (props.scrollTop !== undefined) scrollView.value.scrollTop = Number(props.scrollTop) || 0
-		if (props.scrollLeft !== undefined) scrollView.value.scrollLeft = Number(props.scrollLeft) || 0
+		if (props.scrollTop !== undefined || props.scrollLeft !== undefined) {
+			scrollView.value.scrollTo({
+				top: props.scrollTop === undefined ? scrollView.value.scrollTop : Number(props.scrollTop) || 0,
+				left: props.scrollLeft === undefined ? scrollView.value.scrollLeft : Number(props.scrollLeft) || 0,
+				behavior: props.scrollWithAnimation ? 'smooth' : 'instant',
+			})
+		}
 		if (props.scrollIntoView) scrollToChild(props.scrollIntoView)
 	}
 })

--- a/fe/packages/components/src/component/scroll-view/ScrollView.vue
+++ b/fe/packages/components/src/component/scroll-view/ScrollView.vue
@@ -315,7 +315,19 @@ function getScrollDetail(extra = {}) {
 	}
 }
 
+// A smooth initial/programmatic scroll can still be animating away from the
+// top when refresherStartY was captured at scrollTop<=0, so touchmove/touchend
+// must re-check the container is still at the top before treating this as a
+// refresher gesture rather than trusting the touchstart-time snapshot.
+function cancelRefresherGestureAwayFromTop() {
+	if (refresherStartY !== undefined && (scrollView.value?.scrollTop ?? 0) > 0) {
+		refresherStartY = undefined
+		refresherDistance = 0
+	}
+}
+
 function handleEnhancedTouchMove(event) {
+	cancelRefresherGestureAwayFromTop()
 	if (refresherStartY !== undefined) {
 		refresherDistance = Math.max((event.touches?.[0]?.clientY || refresherStartY) - refresherStartY, 0)
 		if (refresherDistance > 0) {
@@ -332,6 +344,7 @@ function handleEnhancedTouchMove(event) {
 }
 
 function handleTouchEnd(event) {
+	cancelRefresherGestureAwayFromTop()
 	if (refresherStartY !== undefined) {
 		if (refresherDistance >= props.refresherThreshold) {
 			refreshing = true

--- a/fe/packages/components/src/component/scroll-view/ScrollView.vue
+++ b/fe/packages/components/src/component/scroll-view/ScrollView.vue
@@ -367,7 +367,7 @@ watch(
 			scrollView.value.scrollTo({
 				top: newScrollTop === undefined ? scrollView.value.scrollTop : Number(newScrollTop) || 0,
 				left: newScrollLeft === undefined ? scrollView.value.scrollLeft : Number(newScrollLeft) || 0,
-				behavior: props.scrollWithAnimation ? 'smooth' : 'auto',
+				behavior: props.scrollWithAnimation ? 'smooth' : 'instant',
 			})
 		}
 	},
@@ -384,7 +384,7 @@ function scrollToChild(id) {
 	scrollView.value.scrollTo({
 		top: props.scrollY ? scrollView.value.scrollTop + targetRect.top - rootRect.top : scrollView.value.scrollTop,
 		left: props.scrollX ? scrollView.value.scrollLeft + targetRect.left - rootRect.left : scrollView.value.scrollLeft,
-		behavior: props.scrollWithAnimation ? 'smooth' : 'auto',
+		behavior: props.scrollWithAnimation ? 'smooth' : 'instant',
 	})
 }
 
@@ -445,7 +445,6 @@ onMounted(() => {
 	}
 
 	&.hide-scrollbar {
-		scroll-behavior: smooth;
 		position: relative;
 	}
 

--- a/fe/packages/components/src/component/scroll-view/ScrollView.vue
+++ b/fe/packages/components/src/component/scroll-view/ScrollView.vue
@@ -319,15 +319,22 @@ function getScrollDetail(extra = {}) {
 // top when refresherStartY was captured at scrollTop<=0, so touchmove/touchend
 // must re-check the container is still at the top before treating this as a
 // refresher gesture rather than trusting the touchstart-time snapshot.
-function cancelRefresherGestureAwayFromTop() {
-	if (refresherStartY !== undefined && (scrollView.value?.scrollTop ?? 0) > 0) {
-		refresherStartY = undefined
-		refresherDistance = 0
+function cancelRefresherGestureAwayFromTop(event) {
+	if (refresherStartY === undefined || (scrollView.value?.scrollTop ?? 0) <= 0) return
+
+	const dy = refresherDistance
+	refresherStartY = undefined
+	refresherDistance = 0
+
+	// A refresherpulling already went out for this gesture; tell the consumer
+	// it ended instead of leaving it without a matching refresh/abort event.
+	if (dy > 0) {
+		triggerEvent('refresherabort', { event, info, detail: { dy } })
 	}
 }
 
 function handleEnhancedTouchMove(event) {
-	cancelRefresherGestureAwayFromTop()
+	cancelRefresherGestureAwayFromTop(event)
 	if (refresherStartY !== undefined) {
 		refresherDistance = Math.max((event.touches?.[0]?.clientY || refresherStartY) - refresherStartY, 0)
 		if (refresherDistance > 0) {
@@ -344,7 +351,7 @@ function handleEnhancedTouchMove(event) {
 }
 
 function handleTouchEnd(event) {
-	cancelRefresherGestureAwayFromTop()
+	cancelRefresherGestureAwayFromTop(event)
 	if (refresherStartY !== undefined) {
 		if (refresherDistance >= props.refresherThreshold) {
 			refreshing = true


### PR DESCRIPTION
## 问题

当 `scroll-with-animation` 未设置(官方文档默认值 `false`)时,通过 `setData` 设置 `scroll-top` / `scroll-left` / `scroll-into-view` 仍然会带动画滚动,而不是立即跳转。这违背了 `scroll-with-animation` 文档里写明的默认行为,而且这个动画滚动过程中如果有别的渲染发生,还可能被打断或卡在中途。

在真实 Electron/Chromium 环境下复现:同一个 `scrollTo()` 调用,本该立即生效,实际却要几百毫秒才视觉上稳定下来。

## 根因

`ScrollView.vue` 里 `scrollTop`/`scrollLeft` 的 watch,以及处理 `scroll-into-view` 的 `scrollToChild`,传的是:

```js
behavior: props.scrollWithAnimation ? 'smooth' : 'auto'
```

`'auto'` 并不是"不带动画"的意思——按 CSSOM View 规范,它的语义是"听从元素当前 CSS 里 `scroll-behavior` 的设置"。而 `.dd-scroll-view.hide-scrollbar` 这条规则设置了 `scroll-behavior: smooth`,`hideScrollBar` 在 `enhanced` 未显式开启时默认为 `true`——也就是说,默认情况下,每一次"不该带动画"的滚动都会被悄悄变成带动画的。

这同时也影响 `onMounted` 里初始化滚动位置的赋值(`scrollView.value.scrollTop = ...`),这条路径根本不经过 `scrollTo()` 的 `behavior` 参数——直接对属性赋值,按规范同样解析为 `'auto'`,完全由 CSS 决定。这也是为什么必须删除这条 CSS 规则,而不能只改两处 `scrollTo()` 调用就了事。

`behavior: 'instant'` 实际上正是这个分支从组件最初提交起就一直硬编码使用的值,直到后来一次改动为了真正支持 `scroll-with-animation` 才把它换成了现在这个三元表达式。在微信官方开发者工具里实测观察到的行为也印证了这一点:非动画的 `scroll-top`/`scroll-into-view` 是立即生效的,不受任何 CSS 影响。

## 修复

- 两处调用都把 `behavior: props.scrollWithAnimation ? 'smooth' : 'auto'` 改成 `props.scrollWithAnimation ? 'smooth' : 'instant'`。
- 删除 `.hide-scrollbar` 里的 `scroll-behavior: smooth`。这个 class 的另一个职责只是隐藏滚动条(`::-webkit-scrollbar { width: 0 }`)——滚动要不要带动画,不应该跟滚动条是否可见绑在一起。

`scroll-with-animation: true` 的行为未受影响,仍然走 `'smooth'`。

## 追加修复

初始化 `scroll-top` / `scroll-left` 现在合并为一次 `scrollTo()` 调用,并统一按 `scroll-with-animation` 选择 `smooth` 或 `instant`,避免平滑滚动时两轴目标相互覆盖。微信在组件初始挂载时同样会走动画判断,因此初始位置非零且开启动画时,首次渲染会平滑滚动到目标位置。

平滑滚动期间,下拉刷新会在 `touchmove` / `touchend` 重新确认容器仍位于顶部;离开顶部后立即取消手势,已触发 `refresherpulling` 时配套发送一次 `refresherabort`。

