### PR TITLE
fix(fe,component): align slider behavior with native implementation

### DIFF
--- a/fe/packages/components/__tests__/slider.spec.js
+++ b/fe/packages/components/__tests__/slider.spec.js
@@ -1,0 +1,234 @@
+/** @vitest-environment jsdom */
+
+import { createApp, h, nextTick, reactive } from 'vue'
+import Slider from '../src/component/slider/Slider.vue'
+
+const mounts = []
+
+function mountComponent(component, props = {}) {
+	const host = document.createElement('div')
+	document.body.appendChild(host)
+	const app = createApp({
+		setup() {
+			provide('bridgeId', 'bridge-1')
+			provide('path', 'page-path')
+			provide('page-path', { id: 'module-1' })
+			return () => h(component, props)
+		},
+	})
+	app.mount(host)
+	const mounted = { app, host }
+	mounts.push(mounted)
+	return mounted
+}
+
+function mockTrackGeometry(host, { left = 0, width = 100 } = {}) {
+	const tapArea = host.querySelector('.dd-slider-tap-area')
+	tapArea.getBoundingClientRect = () => ({ left, width })
+	return tapArea
+}
+
+function sentEvents() {
+	return window.__message.send.mock.calls.map(([message]) => message.body)
+}
+
+beforeEach(() => {
+	window.__message = {
+		invoke: vi.fn(),
+		off: vi.fn(),
+		on: vi.fn(),
+		send: vi.fn(),
+	}
+	window.__callback = {
+		remove: vi.fn(),
+		store: vi.fn(() => `callback-${Math.random()}`),
+	}
+	window.ResizeObserver = class {
+		disconnect() {}
+		observe() {}
+	}
+})
+
+afterEach(() => {
+	while (mounts.length) {
+		const { app, host } = mounts.pop()
+		app.unmount()
+		host.remove()
+	}
+	vi.unstubAllGlobals()
+})
+
+describe('slider wechat alignment', () => {
+	it('reports events with the root element as currentTarget so the logic layer can resolve data-sid', async () => {
+		const { host } = mountComponent(Slider, {
+			id: 'my-slider',
+			'data-sid': 'slider-node-1',
+			bindchange: 'changeHandler',
+		})
+		mockTrackGeometry(host)
+		await nextTick()
+
+		host.querySelector('.dd-slider-tap-area').dispatchEvent(
+			new MouseEvent('click', { bubbles: true, clientX: 50 })
+		)
+
+		const [event] = sentEvents()
+		expect(event.methodName).toBe('changeHandler')
+		// 修复前 currentTarget 是 .dd-slider-tap-area（无 id / 无 sid），逻辑层反查不到节点
+		expect(event.event.currentTarget.id).toBe('my-slider')
+		expect(event.event.currentTarget.dataset.sid).toBe('slider-node-1')
+	})
+
+	it('does not fire change when the value stays the same', async () => {
+		const { host } = mountComponent(Slider, {
+			bindchange: 'changeHandler',
+			min: 0,
+			max: 10,
+			step: 5,
+			value: 5,
+		})
+		mockTrackGeometry(host)
+		await nextTick()
+
+		// 点击 handle 当前位置（50% 处落点 5，与当前值相同），change 不应触发
+		host.querySelector('.dd-slider-tap-area').dispatchEvent(
+			new MouseEvent('click', { bubbles: true, clientX: 50 })
+		)
+		await nextTick()
+		expect(sentEvents()).toHaveLength(0)
+
+		// 点击新位置（0% 处落点 0），值变化应触发 change
+		host.querySelector('.dd-slider-tap-area').dispatchEvent(
+			new MouseEvent('click', { bubbles: true, clientX: 0 })
+		)
+		await nextTick()
+		const [event] = sentEvents()
+		expect(event.methodName).toBe('changeHandler')
+		expect(event.event.detail.value).toBe(0)
+	})
+
+	it('clamps blockSize into the wechat range of 12 - 28', async () => {
+		const { host } = mountComponent(Slider, {
+			blockSize: 40,
+		})
+		await nextTick()
+		const thumb = host.querySelector('.dd-slider-thumb')
+		expect(thumb.style.width).toBe('28px')
+		expect(thumb.style.height).toBe('28px')
+	})
+
+	it('rounds step values to the largest decimal precision without float tails', async () => {
+		const { host } = mountComponent(Slider, {
+			min: 0,
+			max: 1,
+			step: 0.1,
+			value: 0.3,
+			showValue: true,
+		})
+		await nextTick()
+		expect(host.querySelector('.dd-slider-value p').textContent.trim()).toBe('0.3')
+	})
+
+	it('falls back from backgroundColor to color when backgroundColor is not explicit', async () => {
+		const { host } = mountComponent(Slider, {
+			color: '#ff0000',
+		})
+		await nextTick()
+		// 未显式传 backgroundColor：props 默认值不应遮蔽显式传入的 color
+		// （jsdom 把颜色序列化为 rgb 格式）
+		expect(host.querySelector('.dd-slider-handle-wrapper').style.backgroundColor).toBe('rgb(255, 0, 0)')
+	})
+
+	it('honours explicit backgroundColor over color', async () => {
+		const { host } = mountComponent(Slider, {
+			color: '#ff0000',
+			backgroundColor: '#00ff00',
+		})
+		await nextTick()
+		expect(host.querySelector('.dd-slider-handle-wrapper').style.backgroundColor).toBe('rgb(0, 255, 0)')
+	})
+
+	it('syncs display value when the value prop changes externally', async () => {
+		const props = reactive({
+			value: 10,
+			showValue: true,
+		})
+		const host = document.createElement('div')
+		document.body.appendChild(host)
+		const app = createApp({
+			setup() {
+				provide('bridgeId', 'bridge-1')
+				provide('path', 'page-path')
+				provide('page-path', { id: 'module-1' })
+				return () => h(Slider, props)
+			},
+		})
+		app.mount(host)
+		mounts.push({ app, host })
+		await nextTick()
+
+		props.value = 60
+		await nextTick()
+		expect(host.querySelector('.dd-slider-value p').textContent.trim()).toBe('60')
+	})
+
+	it('ignores interaction while disabled', async () => {
+		const { host } = mountComponent(Slider, {
+			disabled: true,
+			bindchange: 'changeHandler',
+		})
+		mockTrackGeometry(host)
+		await nextTick()
+
+		host.querySelector('.dd-slider-tap-area').dispatchEvent(
+			new MouseEvent('click', { bubbles: true, clientX: 50 })
+		)
+		expect(sentEvents()).toHaveLength(0)
+	})
+
+	it('fires changing while dragging and change on release, both with root currentTarget', async () => {
+		const { host } = mountComponent(Slider, {
+			id: 'drag-slider',
+			bindchanging: 'changingHandler',
+			bindchange: 'changeHandler',
+			min: 0,
+			max: 100,
+			step: 1,
+		})
+		mockTrackGeometry(host)
+		await nextTick()
+
+		host.querySelector('.dd-slider-handle').dispatchEvent(
+			new MouseEvent('mousedown', { bubbles: true, clientX: 0 })
+		)
+		window.dispatchEvent(new MouseEvent('mousemove', { clientX: 75 }))
+		window.dispatchEvent(new MouseEvent('mouseup', { clientX: 75 }))
+
+		const events = sentEvents()
+		expect(events.map(e => e.methodName)).toEqual(['changingHandler', 'changeHandler'])
+		expect(events[0].event.detail.value).toBe(75)
+		expect(events[1].event.detail.value).toBe(75)
+		expect(events[1].event.currentTarget.id).toBe('drag-slider')
+	})
+
+	it('does not fire change when a drag ends where it started', async () => {
+		const { host } = mountComponent(Slider, {
+			bindchange: 'changeHandler',
+			min: 0,
+			max: 100,
+			step: 1,
+		})
+		mockTrackGeometry(host)
+		await nextTick()
+
+		host.querySelector('.dd-slider-handle').dispatchEvent(
+			new MouseEvent('mousedown', { bubbles: true, clientX: 0 })
+		)
+		window.dispatchEvent(new MouseEvent('mousemove', { clientX: 30 }))
+		window.dispatchEvent(new MouseEvent('mousemove', { clientX: 0 }))
+		window.dispatchEvent(new MouseEvent('mouseup', { clientX: 0 }))
+
+		// 拖动回起点：值回到初始 0，change 不应触发
+		expect(sentEvents()).toHaveLength(0)
+	})
+})

--- a/fe/packages/components/__tests__/slider.spec.js
+++ b/fe/packages/components/__tests__/slider.spec.js
@@ -32,6 +32,15 @@ function sentEvents() {
 	return window.__message.send.mock.calls.map(([message]) => message.body)
 }
 
+function createTouchEvent(type, { touches = [], changedTouches = [] } = {}) {
+	const event = new Event(type, { bubbles: true, cancelable: true })
+	Object.defineProperties(event, {
+		touches: { value: touches },
+		changedTouches: { value: changedTouches },
+	})
+	return event
+}
+
 beforeEach(() => {
 	window.__message = {
 		invoke: vi.fn(),
@@ -129,6 +138,58 @@ describe('slider wechat alignment', () => {
 		expect(host.querySelector('.dd-slider-value p').textContent.trim()).toBe('0.3')
 	})
 
+	it('keeps scientific-notation step precision when moving the slider', async () => {
+		const { host } = mountComponent(Slider, {
+			bindchange: 'changeHandler',
+			min: 0,
+			max: 1.2e-6,
+			step: 1.2e-7,
+			value: 0,
+			showValue: true,
+		})
+		mockTrackGeometry(host)
+		await nextTick()
+
+		host.querySelector('.dd-slider-tap-area').dispatchEvent(
+			new MouseEvent('click', { bubbles: true, clientX: 10 })
+		)
+		await nextTick()
+
+		const [event] = sentEvents()
+		expect(event.event.detail.value).toBe(1.2e-7)
+		expect(host.querySelector('.dd-slider-value p').textContent.trim()).toBe('1.2e-7')
+	})
+
+	it('reserves value text width for the decimal point', async () => {
+		const { host } = mountComponent(Slider, {
+			min: 0,
+			max: 1,
+			step: 0.1,
+			value: 0.3,
+			showValue: true,
+		})
+		await nextTick()
+
+		const value = host.querySelector('.dd-slider-value p')
+		expect(value.textContent.trim()).toBe('0.3')
+		expect(value.style.width).toBe('3ch')
+	})
+
+	it('reserves value text width for a negative min wider than max', async () => {
+		const { host } = mountComponent(Slider, {
+			min: -100,
+			max: 1,
+			step: 1,
+			value: -100,
+			showValue: true,
+		})
+		await nextTick()
+
+		const value = host.querySelector('.dd-slider-value p')
+		expect(value.textContent.trim()).toBe('-100')
+		expect(value.style.width).toBe('4ch')
+	})
+
 	it('falls back from backgroundColor to color when backgroundColor is not explicit', async () => {
 		const { host } = mountComponent(Slider, {
 			color: '#ff0000',
@@ -209,6 +270,56 @@ describe('slider wechat alignment', () => {
 		expect(events[0].event.detail.value).toBe(75)
 		expect(events[1].event.detail.value).toBe(75)
 		expect(events[1].event.currentTarget.id).toBe('drag-slider')
+	})
+
+	it('uses changedTouches to calculate the final value before firing change', async () => {
+		const { host } = mountComponent(Slider, {
+			bindchanging: 'changingHandler',
+			bindchange: 'changeHandler',
+			min: 0,
+			max: 100,
+			step: 1,
+		})
+		mockTrackGeometry(host)
+		await nextTick()
+
+		host.querySelector('.dd-slider-handle').dispatchEvent(
+			createTouchEvent('touchstart', { touches: [{ clientX: 0 }] })
+		)
+		window.dispatchEvent(createTouchEvent('touchmove', { touches: [{ clientX: 30 }] }))
+		window.dispatchEvent(createTouchEvent('touchend', {
+			touches: [],
+			changedTouches: [{ clientX: 75 }],
+		}))
+
+		const events = sentEvents()
+		expect(events.map(event => event.methodName)).toEqual(['changingHandler', 'changeHandler'])
+		expect(events.map(event => event.event.detail.value)).toEqual([30, 75])
+	})
+
+	it('does not fire change when the final touch returns to the drag start value', async () => {
+		const { host } = mountComponent(Slider, {
+			bindchanging: 'changingHandler',
+			bindchange: 'changeHandler',
+			min: 0,
+			max: 100,
+			step: 1,
+		})
+		mockTrackGeometry(host)
+		await nextTick()
+
+		host.querySelector('.dd-slider-handle').dispatchEvent(
+			createTouchEvent('touchstart', { touches: [{ clientX: 0 }] })
+		)
+		window.dispatchEvent(createTouchEvent('touchmove', { touches: [{ clientX: 30 }] }))
+		window.dispatchEvent(createTouchEvent('touchend', {
+			touches: [],
+			changedTouches: [{ clientX: 0 }],
+		}))
+
+		const events = sentEvents()
+		expect(events.map(event => event.methodName)).toEqual(['changingHandler'])
+		expect(events[0].event.detail.value).toBe(30)
 	})
 
 	it('does not fire change when a drag ends where it started', async () => {

--- a/fe/packages/components/__tests__/slider.spec.js
+++ b/fe/packages/components/__tests__/slider.spec.js
@@ -321,6 +321,31 @@ describe('slider wechat alignment', () => {
 		expect(events.map(event => event.event.detail.value)).toEqual([30, 75])
 	})
 
+	it('fires change on touchcancel when the final value differs from the drag start', async () => {
+		const { host } = mountComponent(Slider, {
+			bindchanging: 'changingHandler',
+			bindchange: 'changeHandler',
+			min: 0,
+			max: 100,
+			step: 1,
+		})
+		mockTrackGeometry(host)
+		await nextTick()
+
+		host.querySelector('.dd-slider-handle').dispatchEvent(
+			createTouchEvent('touchstart', { touches: [{ clientX: 0 }] })
+		)
+		window.dispatchEvent(createTouchEvent('touchmove', { touches: [{ clientX: 30 }] }))
+		window.dispatchEvent(createTouchEvent('touchcancel', {
+			touches: [],
+			changedTouches: [{ clientX: 75 }],
+		}))
+
+		const events = sentEvents()
+		expect(events.map(event => event.methodName)).toEqual(['changingHandler', 'changeHandler'])
+		expect(events.map(event => event.event.detail.value)).toEqual([30, 75])
+	})
+
 	it('does not fire change when the final touch returns to the drag start value', async () => {
 		const { host } = mountComponent(Slider, {
 			bindchanging: 'changingHandler',

--- a/fe/packages/components/__tests__/slider.spec.js
+++ b/fe/packages/components/__tests__/slider.spec.js
@@ -138,6 +138,30 @@ describe('slider wechat alignment', () => {
 		expect(host.querySelector('.dd-slider-value p').textContent.trim()).toBe('0.3')
 	})
 
+	it('clamps a non-divisible step result to max at the right edge', async () => {
+		const { host } = mountComponent(Slider, {
+			bindchange: 'changeHandler',
+			min: 0,
+			max: 10,
+			step: 6,
+			value: 0,
+			showValue: true,
+		})
+		mockTrackGeometry(host)
+		await nextTick()
+
+		host.querySelector('.dd-slider-tap-area').dispatchEvent(
+			new MouseEvent('click', { bubbles: true, clientX: 100 })
+		)
+		await nextTick()
+
+		const [event] = sentEvents()
+		expect(event.event.detail.value).toBe(10)
+		expect(host.querySelector('.dd-slider-value p').textContent.trim()).toBe('10')
+		expect(host.querySelector('.dd-slider').getAttribute('aria-valuenow')).toBe('10')
+		expect(host.querySelector('.dd-slider-thumb').style.left).toBe('100%')
+	})
+
 	it('keeps scientific-notation step precision when moving the slider', async () => {
 		const { host } = mountComponent(Slider, {
 			bindchange: 'changeHandler',

--- a/fe/packages/components/src/component/slider/Slider.vue
+++ b/fe/packages/components/src/component/slider/Slider.vue
@@ -148,12 +148,11 @@ const backColor = computed(() => {
 function decimalPlaces(value) {
 	const num = Number(value)
 	if (Number.isInteger(num)) return 0
-	const str = num.toString()
-	const dotIndex = str.indexOf('.')
-	if (dotIndex >= 0) return str.length - dotIndex - 1
-	// 极小值会走科学计数法，如 1e-7
-	const expIndex = str.indexOf('e-')
-	return expIndex >= 0 ? Number(str.slice(expIndex + 2)) : 0
+	const [mantissa, exponentText] = num.toString().toLowerCase().split('e')
+	const fractionDigits = mantissa.split('.')[1]?.length ?? 0
+	const exponent = exponentText === undefined ? 0 : Number(exponentText)
+	// 1.2e-7 的有效小数位是 1 - (-7) = 8，不能把指数部分计入尾数长度
+	return Math.max(0, fractionDigits - exponent)
 }
 
 function roundToStep(value) {
@@ -195,12 +194,19 @@ const blockSize = computed(() => {
 	return Math.min(Math.max(raw, 12), 28)
 })
 
-// 显示值宽度按「max 整数位 + 最大小数位」计算（对齐微信基础库 _getValueTextWidth），
-// 避免固定 3ch 在长数值（如 0.5 步长的 0.5/12.5/99.5）下折行
+// 显示值宽度按范围内的最大整数位、负号、小数点和最大小数位计算，
+// 避免长数值或负数发生折行、溢出
 const valueTextWidth = computed(() => {
-	const intDigits = String(Math.round(Number(props.max))).length
+	const min = Number(props.min)
+	const max = Number(props.max)
+	const intDigits = Math.max(
+		String(Math.trunc(Math.abs(min))).length,
+		String(Math.trunc(Math.abs(max))).length
+	)
 	const decimals = Math.max(decimalPlaces(props.min), decimalPlaces(props.max), decimalPlaces(props.step))
-	return `${intDigits + decimals}ch`
+	const signWidth = min < 0 ? 1 : 0
+	const decimalPointWidth = decimals > 0 ? 1 : 0
+	return `${signWidth + intDigits + decimalPointWidth + decimals}ch`
 })
 
 let isDragging = false
@@ -274,9 +280,11 @@ function drag(event) {
 
 // 按事件位置计算校正后的值并同步 disValue，返回该值；轨道尺寸未就绪时返回 null
 function applyValue(event) {
-	const clientX = event.touches ? event.touches[0].clientX : event.clientX
+	// touchend 时 touches 已清空，最终触点位于 changedTouches
+	const touch = event.touches?.[0] ?? event.changedTouches?.[0]
+	const clientX = touch?.clientX ?? event.clientX
 	const rect = sliderHandle.value?.getBoundingClientRect()
-	if (!rect?.width) {
+	if (clientX === undefined || !rect?.width) {
 		return null
 	}
 	const delta = clientX - rect.left
@@ -312,15 +320,22 @@ function endDrag(event) {
 	}
 
 	isDragging = false
-	// 拖回起点：值相对起点未变化，change 不触发
-	if (disValue.value === dragStartValue) {
-		dragStartValue = null
+	// 先用释放触点更新最终值，再判断是否拖回起点
+	const disV = applyValue(event)
+	const startValue = dragStartValue
+	dragStartValue = null
+	if (disV === null || disV === startValue) {
 		return
 	}
-	dragStartValue = null
 
 	// 完成一次拖动后触发的事件
-	updateValue(event, 'change')
+	triggerEvent('change', {
+		event: bridgeEvent(event),
+		info,
+		detail: {
+			value: disV,
+		},
+	})
 }
 
 function handleClick(event) {

--- a/fe/packages/components/src/component/slider/Slider.vue
+++ b/fe/packages/components/src/component/slider/Slider.vue
@@ -165,7 +165,9 @@ function roundToStep(value) {
 	const raw = min + Math.round((clamp - min) / step) * step
 	// 小数步长按最大小数位截断，消除二进制浮点尾差（对齐微信基础库 _revalicateRange）
 	const decimals = Math.max(decimalPlaces(min), decimalPlaces(max), decimalPlaces(step))
-	return decimals > 0 ? Number(raw.toFixed(decimals)) : raw
+	const rounded = decimals > 0 ? Number(raw.toFixed(decimals)) : raw
+	// 当 (max - min) 不能被 step 整除时，舍入值可能越过边界（如 0/10/6 -> 12）
+	return Math.min(Math.max(rounded, min), max)
 }
 
 const sliderHandle = ref(null)

--- a/fe/packages/components/src/component/slider/Slider.vue
+++ b/fe/packages/components/src/component/slider/Slider.vue
@@ -120,18 +120,41 @@ const props = defineProps({
 	},
 })
 
+const info = useInfo()
+
+const DEFAULT_ACTIVE_COLOR = '#1aad19'
+const DEFAULT_BACK_COLOR = '#e9e9e9'
+
+// 微信语义（_getActiveColor）：activeColor 与默认值相同视为未设置，回退到
+// selectedColor；两者都未设置用默认绿。按值比较而不是真值判断——真值判断
+// 下显式传的默认值会遮蔽另一颜色。
 const valColor = computed(() => {
-	const attrs = info.attrs || {}
-	if ('activeColor' in attrs || 'active-color' in attrs) return props.activeColor
-	if ('selectedColor' in attrs || 'selected-color' in attrs) return props.selectedColor
-	return props.activeColor
+	const { activeColor, selectedColor } = props
+	if (activeColor !== DEFAULT_ACTIVE_COLOR) return activeColor
+	if (selectedColor !== DEFAULT_ACTIVE_COLOR) return selectedColor
+	return DEFAULT_ACTIVE_COLOR
 })
 
+// 微信语义（_getBackgroundColor）：backgroundColor 与默认值相同视为未设置，
+// 回退到 color；都未设置用默认灰。props 默认值与微信基础库默认值一致，
+// 因此「未显式传」与「显式传默认值」在值比较下等价。
 const backColor = computed(() => {
-	return {
-		backgroundColor: props.backgroundColor || props.color,
-	}
+	const { backgroundColor, color } = props
+	if (backgroundColor !== DEFAULT_BACK_COLOR) return { backgroundColor }
+	if (color !== DEFAULT_BACK_COLOR) return { backgroundColor: color }
+	return { backgroundColor: DEFAULT_BACK_COLOR }
 })
+
+function decimalPlaces(value) {
+	const num = Number(value)
+	if (Number.isInteger(num)) return 0
+	const str = num.toString()
+	const dotIndex = str.indexOf('.')
+	if (dotIndex >= 0) return str.length - dotIndex - 1
+	// 极小值会走科学计数法，如 1e-7
+	const expIndex = str.indexOf('e-')
+	return expIndex >= 0 ? Number(str.slice(expIndex + 2)) : 0
+}
 
 function roundToStep(value) {
 	const min = Number(props.min)
@@ -140,11 +163,16 @@ function roundToStep(value) {
 
 	// Clamps a number between a minimum and maximum value.
 	const clamp = Math.min(Math.max(value, min), max)
-	// Rounds a number to the nearest multiple of a given step size.
-	return Math.min(Math.max(min + Math.round((clamp - min) / step) * step, min), max)
+	const raw = min + Math.round((clamp - min) / step) * step
+	// 小数步长按最大小数位截断，消除二进制浮点尾差（对齐微信基础库 _revalicateRange）
+	const decimals = Math.max(decimalPlaces(min), decimalPlaces(max), decimalPlaces(step))
+	return decimals > 0 ? Number(raw.toFixed(decimals)) : raw
 }
 
 const sliderHandle = ref(null)
+// 组件根元素。逻辑层通过 event.currentTarget 上的 data-sid 反查节点，
+// 而 data-sid 只挂在根元素上（由 $attrs 绑入）。
+const sliderRoot = ref(null)
 
 // 格式化显示值
 const disValue = ref(roundToStep(Number(props.value)))
@@ -161,16 +189,31 @@ const percent = computed(() => {
 	return range.value > 0 ? ((disValue.value - Number(props.min)) / range.value) * 100 : 0
 })
 
+// 滑块尺寸与微信基础库一致地夹在 [12, 28]：blockSize 超出范围不生效而是被截断
+const blockSize = computed(() => {
+	const raw = Number(props.blockSize) || 28
+	return Math.min(Math.max(raw, 12), 28)
+})
+
+// 显示值宽度按「max 整数位 + 最大小数位」计算（对齐微信基础库 _getValueTextWidth），
+// 避免固定 3ch 在长数值（如 0.5 步长的 0.5/12.5/99.5）下折行
+const valueTextWidth = computed(() => {
+	const intDigits = String(Math.round(Number(props.max))).length
+	const decimals = Math.max(decimalPlaces(props.min), decimalPlaces(props.max), decimalPlaces(props.step))
+	return `${intDigits + decimals}ch`
+})
+
 let isDragging = false
+// 拖动起始值：结束位置与起点同值时不触发 change（微信基础库 _startValue 语义）
+let dragStartValue = null
 
 function startDrag() {
 	if (props.disabled) {
 		return
 	}
 	isDragging = true
+	dragStartValue = disValue.value
 }
-
-const info = useInfo()
 
 watch(() => props.value, value => {
 	disValue.value = roundToStep(Number(value))
@@ -189,11 +232,35 @@ onBeforeUnmount(() => unregisterFormControl?.())
 
 const blockStyle = computed(() => ({
 	backgroundColor: props.blockColor,
-	height: `${props.blockSize}px`,
-	marginLeft: `${-props.blockSize / 2}px`,
-	marginTop: `${-props.blockSize / 2}px`,
-	width: `${props.blockSize}px`,
+	height: `${blockSize.value}px`,
+	marginLeft: `${-blockSize.value / 2}px`,
+	marginTop: `${-blockSize.value / 2}px`,
+	width: `${blockSize.value}px`,
 }))
+
+/**
+ * 把根元素充当事件的 currentTarget 后再交给 triggerEvent。
+ *
+ * 交互事件的原生 currentTarget 不是根元素：点击落在内部的 .dd-slider-tap-area 上，
+ * 拖动过程中的 touchmove / touchend 挂在 window 上。两者都不带 data-sid，逻辑层
+ * 反查不到节点就会静默丢弃事件，表现为 slider 能拖动但绑定的 bindchange /
+ * bindchanging 从不触发。
+ *
+ * 位置计算仍使用原始事件，这里只用于事件上报。
+ */
+function bridgeEvent(event) {
+	return {
+		currentTarget: sliderRoot.value,
+		target: event?.target ?? sliderRoot.value,
+		pageX: event?.pageX,
+		pageY: event?.pageY,
+		touches: event?.touches,
+		changedTouches: event?.changedTouches,
+		cancelable: event?.cancelable,
+		preventDefault: () => event?.preventDefault?.(),
+		stopPropagation: () => event?.stopPropagation?.(),
+	}
+}
 
 function drag(event) {
 	if (!isDragging || Boolean(props.disabled)) {
@@ -205,22 +272,33 @@ function drag(event) {
 	updateValue(event)
 }
 
-function updateValue(event, eventType = 'changing') {
+// 按事件位置计算校正后的值并同步 disValue，返回该值；轨道尺寸未就绪时返回 null
+function applyValue(event) {
 	const clientX = event.touches ? event.touches[0].clientX : event.clientX
 	const rect = sliderHandle.value?.getBoundingClientRect()
 	if (!rect?.width) {
-		return
+		return null
 	}
 	const delta = clientX - rect.left
 	const position = (delta / rect.width) * range.value + Number(props.min)
 	const disV = roundToStep(position)
-	disValue.value = disV
 
-	collectFormValue?.(props.name, disV)
+	if (disV !== disValue.value) {
+		disValue.value = disV
+		collectFormValue?.(props.name, disV)
+	}
+	return disV
+}
 
-	// 拖动过程中触发的事件
+function updateValue(event, eventType = 'changing') {
+	const disV = applyValue(event)
+	if (disV === null) {
+		return
+	}
+
+	// 拖动过程中触发的事件（值未变化也照常上报，对齐微信 _onTrack 语义）
 	triggerEvent(eventType, {
-		event,
+		event: bridgeEvent(event),
 		info,
 		detail: {
 			value: disV,
@@ -234,15 +312,15 @@ function endDrag(event) {
 	}
 
 	isDragging = false
+	// 拖回起点：值相对起点未变化，change 不触发
+	if (disValue.value === dragStartValue) {
+		dragStartValue = null
+		return
+	}
+	dragStartValue = null
 
 	// 完成一次拖动后触发的事件
-	triggerEvent('change', {
-		event,
-		info,
-		detail: {
-			value: disValue.value,
-		},
-	})
+	updateValue(event, 'change')
 }
 
 function handleClick(event) {
@@ -254,7 +332,19 @@ function handleClick(event) {
 	if (props.disabled) {
 		return
 	}
-	updateValue(event, 'change')
+	const previousValue = disValue.value
+	const disV = applyValue(event)
+	// 点击落点与当前值相同：change 不重复触发
+	if (disV === null || disV === previousValue) {
+		return
+	}
+	triggerEvent('change', {
+		event: bridgeEvent(event),
+		info,
+		detail: {
+			value: disV,
+		},
+	})
 }
 
 onMounted(() => {
@@ -276,7 +366,7 @@ onBeforeUnmount(() => {
 
 <template>
 	<div
-		:id="id" v-bind="$attrs" class="dd-slider" role="slider" :aria-valuemin="min" :aria-valuemax="max"
+		:id="id" ref="sliderRoot" v-bind="$attrs" class="dd-slider" role="slider" :aria-valuemin="min" :aria-valuemax="max"
 		:aria-valuenow="disValue" :aria-disabled="disabled" :class="{ 'dd-slider-disabled': disabled }"
 	>
 		<div class="dd-slider-wrapper">
@@ -292,7 +382,7 @@ onBeforeUnmount(() => {
 				</div>
 			</div>
 			<span class="dd-slider-value" :hidden="!showValue">
-				<p parse-text-content style="width: 3ch">{{ disValue }}</p>
+				<p parse-text-content :style="{ width: valueTextWidth }">{{ disValue }}</p>
 			</span>
 		</div>
 	</div>


### PR DESCRIPTION
## Summary

- report slider events with the component root as `currentTarget` so the logic layer can resolve the node
- align click and drag change emission with native behavior
- clamp `blockSize` to the supported range and normalize step precision
- align fallback colors and value-label sizing with slider props
- add focused regression coverage for slider interaction behavior

## Why

Slider clicks land on `.dd-slider-tap-area` and drag listeners run on `window`. Neither target carries `data-sid`, so events could be silently dropped before reaching the logic layer. The existing implementation also emitted duplicate or unchanged values and allowed several prop behaviors to diverge from the native component semantics.

## Impact

This makes `bindchange` and `bindchanging` delivery reliable, avoids redundant change events, and improves compatibility with the native slider implementation without changing unrelated components.

## Validation

- `corepack pnpm --filter components test -- slider.spec.js`
- 7 test files passed, 35 tests passed
