### PR TITLE
fix(sdk): single-owner App/Page visibility with ready-gated delivery

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -2,9 +2,9 @@ name: iOS Tests
 
 on:
   push:
-    paths: ['iOS/**', 'shared/**', '.github/workflows/ios-tests.yml']
+    paths: ['iOS/**', 'harmony/**', 'shared/**', '.github/workflows/ios-tests.yml']
   pull_request:
-    paths: ['iOS/**', 'shared/**', '.github/workflows/ios-tests.yml']
+    paths: ['iOS/**', 'harmony/**', 'shared/**', '.github/workflows/ios-tests.yml']
   workflow_dispatch:
 
 jobs:

--- a/android/dimina/src/main/kotlin/com/didi/dimina/api/route/RouteApi.kt
+++ b/android/dimina/src/main/kotlin/com/didi/dimina/api/route/RouteApi.kt
@@ -4,6 +4,7 @@ import com.didi.dimina.api.APIResult
 import com.didi.dimina.api.AsyncResult
 import com.didi.dimina.api.BaseApiHandler
 import com.didi.dimina.common.ApiUtils
+import com.didi.dimina.common.LogUtils
 import com.didi.dimina.core.BundledMiniProgramResolver
 import com.didi.dimina.core.MiniApp
 import com.didi.dimina.ui.container.DiminaActivity
@@ -19,6 +20,36 @@ internal fun miniProgramSuccessResult(apiName: String, afterComplete: () -> Unit
 
 internal fun miniProgramErrorResult(apiName: String, errorMessage: String): AsyncResult {
     return ApiUtils.createErrorResponse(apiName, errorMessage).copy(completeCarriesResult = true)
+}
+
+/**
+ * Runs one cross-mini-program operation behind [guard], which admits a single operation at a time.
+ *
+ * The operation itself runs from `afterComplete`, once success and complete have already reached
+ * the page - suspending the opener's runtime any earlier would strand those callbacks. A failure
+ * past that point therefore has no `fail` left to report, and letting it out would take the JS
+ * runtime's message loop down with it, so it is contained here. Everything the operation can throw
+ * rolls its own state back first (`MiniApp.openApp` drops the runtime it registered,
+ * `DiminaActivity` restores the suspended opener), leaving the opener usable and the call
+ * retryable.
+ */
+internal fun miniProgramOperationResult(
+    apiName: String,
+    guard: MiniProgramOperationGuard,
+    action: () -> Unit,
+): AsyncResult {
+    if (!guard.tryBegin()) {
+        return miniProgramErrorResult(apiName, "another mini program operation is in progress")
+    }
+    return miniProgramSuccessResult(apiName) {
+        try {
+            action()
+        } catch (error: Exception) {
+            LogUtils.e("RouteApi", "$apiName failed after success was reported: ${error.message}")
+        } finally {
+            guard.end()
+        }
+    }
 }
 
 /**
@@ -220,24 +251,7 @@ class RouteApi : BaseApiHandler() {
         }
     }
 
-    private fun success(apiName: String, afterComplete: () -> Unit): AsyncResult {
-        return miniProgramSuccessResult(apiName, afterComplete)
-    }
-
     private fun withMiniProgramOperation(apiName: String, action: () -> Unit): AsyncResult {
-        if (!miniProgramOperationGuard.tryBegin()) {
-            return miniProgramErrorResult(
-                apiName,
-                "another mini program operation is in progress",
-            )
-        }
-        return success(apiName) {
-            try {
-                action()
-            }
-            finally {
-                miniProgramOperationGuard.end()
-            }
-        }
+        return miniProgramOperationResult(apiName, miniProgramOperationGuard, action)
     }
 }

--- a/android/dimina/src/main/kotlin/com/didi/dimina/core/AppVisibilityLedger.kt
+++ b/android/dimina/src/main/kotlin/com/didi/dimina/core/AppVisibilityLedger.kt
@@ -1,0 +1,64 @@
+package com.didi.dimina.core
+
+import org.json.JSONObject
+
+internal data class AppVisibilityDelivery(
+    val visible: Boolean,
+    val options: JSONObject? = null,
+)
+
+/** Keeps app visibility until the service-side App instance can receive it. */
+internal class AppVisibilityLedger {
+    private var serviceReady = false
+    private var desiredVisible: Boolean? = null
+    private var sentVisible: Boolean? = null
+    private var pendingShowOptions: JSONObject? = null
+
+    @Synchronized
+    fun onShow(options: JSONObject? = null): AppVisibilityDelivery? {
+        if (options != null) {
+            pendingShowOptions = JSONObject(options.toString())
+        }
+        desiredVisible = true
+        return flush()
+    }
+
+    @Synchronized
+    fun onHide(): AppVisibilityDelivery? {
+        desiredVisible = false
+        return flush()
+    }
+
+    @Synchronized
+    fun onServiceReady(): AppVisibilityDelivery? {
+        if (serviceReady) return null
+        serviceReady = true
+        // Creating the service-side App already emits its initial App.onShow.
+        sentVisible = true
+        return flush()
+    }
+
+    @Synchronized
+    fun reset() {
+        serviceReady = false
+        desiredVisible = null
+        sentVisible = null
+        pendingShowOptions = null
+    }
+
+    private fun flush(): AppVisibilityDelivery? {
+        val visible = desiredVisible ?: return null
+        if (!serviceReady) return null
+        if (sentVisible == visible && !(visible && pendingShowOptions != null)) return null
+
+        val delivery = AppVisibilityDelivery(
+            visible = visible,
+            options = pendingShowOptions?.let { JSONObject(it.toString()) }.takeIf { visible },
+        )
+        if (visible) {
+            pendingShowOptions = null
+        }
+        sentVisible = visible
+        return delivery
+    }
+}

--- a/android/dimina/src/main/kotlin/com/didi/dimina/core/Bridge.kt
+++ b/android/dimina/src/main/kotlin/com/didi/dimina/core/Bridge.kt
@@ -21,6 +21,19 @@ import org.json.JSONObject
 import java.io.File
 
 /**
+ * 拆掉一个页面运行时状态的两种原因。微信里 unloadPage 只有路由事件（reLaunch/
+ * redirectTo/navigateBack/switchTab）会触发，退出小程序走的是 onAppEnterBackground，
+ * 只派发 App.onHide，页面不收 onUnload。
+ */
+enum class PageStateTeardown {
+    /** 路由卸载页面：页面确实被路由销毁。 */
+    ROUTING,
+
+    /** 退出小程序或整体换运行时：运行时随后整体销毁，页面不派发 onUnload。 */
+    EXIT,
+}
+
+/**
  * Author: Doslin
  */
 class Bridge(
@@ -39,12 +52,12 @@ class Bridge(
     private var destroyed: Boolean = false
     @Volatile
     private var resourceLoadId: String? = null
-    @Volatile
-    private var desiredPageVisible: Boolean? = null
-    @Volatile
-    private var sentPageVisible: Boolean? = null
-    @Volatile
-    private var pendingAppShowOptions: JSONObject? = null
+    private val pageVisibilityLedger = PageVisibilityLedger { delivery ->
+        options.jscore.postMessage(
+            if (delivery == PageVisibilityDelivery.SHOW) "pageShow" else "pageHide",
+            mapOf("bridgeId" to id)
+        )
+    }
 
     /**
      * Bridge 初始化逻辑
@@ -83,11 +96,7 @@ class Bridge(
         val currentResourceLoadId = synchronized(this) {
             destroyed = false
             resourceLoadId = Utils.uuid()
-            if (visible != null) {
-                desiredPageVisible = visible
-            } else if (desiredPageVisible == null) {
-                desiredPageVisible = true
-            }
+            pageVisibilityLedger.onStart(visible)
             resourceLoadId!!
         }
 
@@ -187,7 +196,9 @@ class Bridge(
             "service" -> {
                 when (type) {
                     "serviceResourceLoaded" -> {
-                        if (markResourceLoaded(service = true)) {
+                        val resourceLoaded = markResourceLoaded(service = true)
+                        options.jscore.notifyServiceReady()
+                        if (resourceLoaded) {
                             transMsg.put("type", "resourceLoaded")
                         } else {
                             return null
@@ -294,80 +305,22 @@ class Bridge(
         }
         options.jscore.postMessage(msg.toString())
         if (msg.optString("type") == "resourceLoaded") {
-            flushPendingAppShow()
-            flushPageVisibility()
+            pageVisibilityLedger.onResourceReady()
         }
-    }
-
-    fun appShow(enterOptions: JSONObject? = null) {
-        val pending = synchronized(this) {
-            if (enterOptions != null) {
-                pendingAppShowOptions = JSONObject(enterOptions.toString())
-            }
-            if (!isResourceLoaded()) {
-                return
-            }
-            pendingAppShowOptions.also { pendingAppShowOptions = null }
-        }
-        if (pending == null) {
-            options.jscore.postMessage(type = "appShow")
-        } else {
-            postAppShow(pending)
-        }
-    }
-
-    fun appHide() {
-        if (!isResourceLoaded()) {
-            return
-        }
-        options.jscore.postMessage(type="appHide")
     }
 
     fun pageShow() {
-        desiredPageVisible = true
-        flushPageVisibility()
+        pageVisibilityLedger.onShow()
     }
 
     fun pageHide() {
-        desiredPageVisible = false
-        flushPageVisibility()
+        pageVisibilityLedger.onHide()
     }
 
-    @Synchronized
-    private fun flushPageVisibility() {
-        val visible = desiredPageVisible
-        if (!isResourceLoaded() || visible == null || sentPageVisible == visible) {
-            return
-        }
-
-        options.jscore.postMessage(
-            if (visible) "pageShow" else "pageHide",
-            mapOf("bridgeId" to id)
-        )
-        sentPageVisible = visible
-    }
-
-    private fun flushPendingAppShow() {
-        val pending = synchronized(this) {
-            if (!isResourceLoaded()) return
-            pendingAppShowOptions.also { pendingAppShowOptions = null }
-        } ?: return
-        postAppShow(pending)
-    }
-
-    private fun postAppShow(enterOptions: JSONObject) {
-        val body = JSONObject(enterOptions.toString()).apply {
-            if (!has("pagePath")) {
-                put("pagePath", options.pathInfo.pagePath)
-            }
-            if (!has("query")) {
-                put("query", options.pathInfo.query ?: JSONObject())
-            }
-        }
-        options.jscore.postMessage("appShow", body)
-    }
-
-    fun destroy(keepHandler: Boolean = false) {
+    fun destroy(
+        keepHandler: Boolean = false,
+        reason: PageStateTeardown = PageStateTeardown.ROUTING,
+    ) {
         parent.clearNativeComponents(this)
         val wasResourceLoaded = isResourceLoaded()
         synchronized(this) {
@@ -376,13 +329,11 @@ class Bridge(
             renderResource = false
             resourceLoadedForwarded = false
             resourceLoadId = null
-            desiredPageVisible = null
-            sentPageVisible = null
-            pendingAppShowOptions = null
+            pageVisibilityLedger.reset()
         }
 
-        // 发送页面卸载消息
-        if (wasResourceLoaded) {
+        // 发送页面卸载消息。退出小程序不是路由，页面不该收 onUnload——运行时紧接着整体销毁。
+        if (wasResourceLoaded && reason == PageStateTeardown.ROUTING) {
             options.jscore.postMessage("pageUnload", mapOf("bridgeId" to id))
         }
 

--- a/android/dimina/src/main/kotlin/com/didi/dimina/core/JsCore.kt
+++ b/android/dimina/src/main/kotlin/com/didi/dimina/core/JsCore.kt
@@ -21,6 +21,7 @@ class JsCore {
     private val runtimeMessageQueue = RuntimeMessageQueue { action ->
         mainHandler.post(action)
     }
+    private val appVisibilityLedger = AppVisibilityLedger()
     // 记录所有已加载的 JS 文件路径
     private val loadedJsPaths = mutableSetOf<String>()
 
@@ -201,6 +202,35 @@ class JsCore {
         }
     }
 
+    @Synchronized
+    fun appShow(options: JSONObject? = null) {
+        dispatchAppVisibility(appVisibilityLedger.onShow(options))
+    }
+
+    @Synchronized
+    fun appHide() {
+        dispatchAppVisibility(appVisibilityLedger.onHide())
+    }
+
+    @Synchronized
+    fun notifyServiceReady() {
+        dispatchAppVisibility(appVisibilityLedger.onServiceReady())
+    }
+
+    private fun dispatchAppVisibility(delivery: AppVisibilityDelivery?) {
+        delivery ?: return
+        if (delivery.visible) {
+            val options = delivery.options
+            if (options == null) {
+                postMessage(type = "appShow")
+            } else {
+                postMessage(type = "appShow", body = options)
+            }
+        } else {
+            postMessage(type = "appHide")
+        }
+    }
+
     /**
      * Enqueues lifecycle work behind every service message already posted to this runtime.
      * Destructive API actions use this instead of a delay so callback ordering is deterministic.
@@ -213,7 +243,8 @@ class JsCore {
 
     /**
      * Stops accepting new service messages and destroys QuickJS behind every message already
-     * queued for this runtime. Bridge.destroy() can therefore deliver Page.onUnload first.
+     * queued for this runtime, so App.onHide and every terminal API callback still reach the page
+     * before the engine goes away.
      */
     fun destroyAfterMessages() {
         runtimeMessageQueue.closeAfterPending {
@@ -240,6 +271,7 @@ class JsCore {
     }
 
     private fun destroyEngine() {
+        appVisibilityLedger.reset()
         if (!::jsEngine.isInitialized) return
         loadedJsPaths.clear()
         jsEngine.destroy()

--- a/android/dimina/src/main/kotlin/com/didi/dimina/core/MiniApp.kt
+++ b/android/dimina/src/main/kotlin/com/didi/dimina/core/MiniApp.kt
@@ -94,9 +94,21 @@ class MiniApp private constructor() {
      */
     fun openApp(context: Activity, miniProgram: MiniProgram) {
         // Initialize or get JsCore for this MiniProgram
+        val alreadyRunning = isRunning(miniProgram.appId)
         getOrCreateJsCore(miniProgram.appId, context)
 
-        DiminaActivity.launch(context, miniProgram)
+        try {
+            DiminaActivity.launch(context, miniProgram)
+        } catch (error: Exception) {
+            // The runtime is registered before the Activity exists. A start that never happened
+            // would otherwise leave [isRunning] true with no Activity to ever clear it, and every
+            // retry would be rejected by navigateToMiniProgram's "already running" guard.
+            if (!alreadyRunning) {
+                LogUtils.e(tag, "Rolling back runtime for ${miniProgram.appId}: ${error.message}")
+                clear(miniProgram.appId)
+            }
+            throw error
+        }
     }
 
     @Synchronized
@@ -122,6 +134,14 @@ class MiniApp private constructor() {
     fun getJsCore(appId: String, context: Context? = null): JsCore {
         return getOrCreateJsCore(appId, context)
     }
+
+    /**
+     * Look up an already-running JsCore without creating one. A JsCore built without a real
+     * Context never loads service.js (see [getOrCreateJsCore]), so callers that only want to
+     * forward a lifecycle signal - and have no Context to hand over synchronously on the
+     * caller's thread - must use this instead of [getJsCore].
+     */
+    fun peekJsCore(appId: String): JsCore? = jsCoreMap[appId]
 
     fun postUpdateStatus(appId: String, event: String) {
         jsCoreMap[appId]?.postMessage("onUpdateStatusChange", mapOf("event" to event))

--- a/android/dimina/src/main/kotlin/com/didi/dimina/core/PageVisibilityLedger.kt
+++ b/android/dimina/src/main/kotlin/com/didi/dimina/core/PageVisibilityLedger.kt
@@ -1,0 +1,78 @@
+package com.didi.dimina.core
+
+internal enum class PageVisibilityDelivery { SHOW, HIDE }
+
+/**
+ * Keeps a [Bridge]'s page visibility until both its render (WebView) and service (JsCore)
+ * resources have loaded. Lives on Bridge, not JsCore: readiness here is "has *this page's*
+ * WebView also reported `renderResourceLoaded`", and JsCore has no visibility into that - only
+ * the Bridge that owns both the WebView and the JsCore reference can see it. Mirrors
+ * [AppVisibilityLedger]'s show/hide-intent-can-arrive-before-ready shape, but that one lives
+ * inside JsCore because its own readiness signal (`onServiceReady`) is purely internal to the
+ * engine - JsCore already knows that fact about itself, unlike this ledger's cross-Bridge fact.
+ *
+ * [deliver] runs inside the ledger's own monitor, so the order messages reach the service is the
+ * order of the transitions that produced them. Intents arrive on different threads - `pageShow`/
+ * `pageHide` on the main thread, readiness on the WebView's JavaBridge thread - and handing the
+ * delivery back to the caller to send afterwards would let a later transition overtake an earlier
+ * one, leaving the service visible while the ledger records hidden (or the reverse), a state no
+ * later intent can correct because the ledger suppresses what it believes was already sent.
+ */
+internal class PageVisibilityLedger(private val deliver: (PageVisibilityDelivery) -> Unit) {
+    private var ready = false
+    private var desiredVisible: Boolean? = null
+    private var sentVisible: Boolean? = null
+
+    /**
+     * [Bridge.start] seeds the initial intent: an explicit value wins, otherwise an intent
+     * already recorded (e.g. an early [onHide]) is kept, otherwise a page starts out wanting to
+     * be shown.
+     */
+    @Synchronized
+    fun onStart(explicitVisible: Boolean? = null) {
+        desiredVisible = explicitVisible ?: (desiredVisible ?: true)
+        flush()
+    }
+
+    @Synchronized
+    fun onShow() {
+        desiredVisible = true
+        flush()
+    }
+
+    @Synchronized
+    fun onHide() {
+        desiredVisible = false
+        flush()
+    }
+
+    /** Both resources have now loaded. A no-op past the first call for this generation. */
+    @Synchronized
+    fun onResourceReady() {
+        if (ready) return
+        ready = true
+        flush()
+    }
+
+    @Synchronized
+    fun reset() {
+        ready = false
+        desiredVisible = null
+        sentVisible = null
+    }
+
+    private fun flush() {
+        val visible = desiredVisible ?: return
+        if (!ready || sentVisible == visible) return
+
+        // A page that was never shown does not owe a pageHide - the service side never created
+        // page state for it to begin with.
+        if (!visible && sentVisible == null) {
+            sentVisible = false
+            return
+        }
+
+        sentVisible = visible
+        deliver(if (visible) PageVisibilityDelivery.SHOW else PageVisibilityDelivery.HIDE)
+    }
+}

--- a/android/dimina/src/main/kotlin/com/didi/dimina/ui/container/DiminaActivity.kt
+++ b/android/dimina/src/main/kotlin/com/didi/dimina/ui/container/DiminaActivity.kt
@@ -116,6 +116,7 @@ import com.didi.dimina.common.Utils
 import com.didi.dimina.common.VersionUtils
 import com.didi.dimina.core.Bridge
 import com.didi.dimina.core.MiniApp
+import com.didi.dimina.core.PageStateTeardown
 import com.didi.dimina.core.RemoteUpdateManager
 import com.didi.dimina.ui.theme.DiminaAndroidTheme
 import com.didi.dimina.ui.view.ActionSheet
@@ -145,6 +146,7 @@ import kotlin.math.sin
 class DiminaActivity : ComponentActivity() {
     private val tag = "DiminaActivity"
     private val isLoading = mutableStateOf(true)
+    private var suspendedForMiniProgramNavigation = false
 
     // UI state for navigation bar
     private val showNavigationBar = mutableStateOf(true)
@@ -285,6 +287,13 @@ class DiminaActivity : ComponentActivity() {
     private var adjustBottom = 0.0
     private var preserveMiniAppOnDestroy = false
     private var pageResourcesReleased = false
+
+    /**
+     * 这个页面 Activity 因何而销毁。每个页面都是一个 Activity，onDestroy 既覆盖 navigateBack
+     * 这类路由卸载，也覆盖退出小程序时整栈一起 finish——只有前者该派发 Page.onUnload。默认按
+     * 路由处理（含系统回收），关栈的一方在 finish() 之前改写它。
+     */
+    private var pageStateTeardownReason = PageStateTeardown.ROUTING
 
     // 屏幕高度
     private var screenHeight = 0
@@ -744,6 +753,7 @@ class DiminaActivity : ComponentActivity() {
             this.bridge = bridge
         }
         miniApp.startUpdateCheckIfNeeded(applicationContext, miniProgram)
+        reconcileAppVisibilityWithCore()
         return bridge
     }
 
@@ -1515,7 +1525,7 @@ class DiminaActivity : ComponentActivity() {
         }
     }
 
-    private fun releasePageResources() {
+    private fun releasePageResources(reason: PageStateTeardown) {
         if (pageResourcesReleased || !isMiniProgramInitialized) return
         pageResourcesReleased = true
 
@@ -1527,7 +1537,7 @@ class DiminaActivity : ComponentActivity() {
         }.distinct()
 
         bridgesToDestroy.forEach { cBridge ->
-            miniApp.removeBridge(miniProgram.appId, cBridge)?.destroy()
+            miniApp.removeBridge(miniProgram.appId, cBridge)?.destroy(reason = reason)
         }
         bridge = null
         tabPageStates.values.forEach { it.bridge = null }
@@ -1545,7 +1555,8 @@ class DiminaActivity : ComponentActivity() {
         // 这批 Activity 的 onDestroy 可能晚于新 Activity 创建，由重启协调者统一
         // clear MiniApp，避免旧页面再次清掉刚创建的新 JS 运行时。
         preserveMiniAppOnDestroy = true
-        releasePageResources()
+        // 冷重启是「关掉再重开」而不是一次路由：旧运行时紧接着整体销毁，不补 onUnload。
+        releasePageResources(PageStateTeardown.EXIT)
 
         val ownedWebViews = buildList {
             webView?.let { add(it) }
@@ -1568,36 +1579,39 @@ class DiminaActivity : ComponentActivity() {
     }
 
     /**
-     * WebSocket 的后台判据挂在 onStart/onStop 而不是 onResume/onPause 上：权限弹窗、系统
-     * 分享面板和对话框式的系统选择器只会让这个 Activity onPause，它仍然可见，小程序也并没有
-     * 进入后台；按 onPause 判定会在用户停留超过后台宽限期时误杀掉全部连接。真正的迁移由
-     * [visibilityTracker] 按 appId 判定，多页面小程序在自己的页面之间跳转不构成前后台变化。
+     * 系统前后台变化由 onStart/onStop 驱动；跨小程序 API 则在 owner 交接时显式更新同一份
+     * [visibilityTracker]。onPause 不作为 App 后台判据，避免权限弹窗或系统面板误杀连接。
      */
     override fun onStart() {
         super.onStart()
         if (isMiniProgramInitialized && visibilityTracker.onActivityVisible(miniProgram.appId, this)) {
-            com.didi.dimina.api.network.WebSocketManager.shared.setBackgrounded(miniProgram.appId, false)
+            dispatchMiniProgramShow()
         }
+        suspendedForMiniProgramNavigation = false
     }
 
     override fun onStop() {
         if (isMiniProgramInitialized && visibilityTracker.onActivityHidden(miniProgram.appId, this)) {
-            com.didi.dimina.api.network.WebSocketManager.shared.setBackgrounded(miniProgram.appId, true)
+            dispatchMiniProgramHide()
         }
         super.onStop()
     }
 
     override fun onResume() {
         super.onResume()
+        if (suspendedForMiniProgramNavigation) {
+            if (visibilityTracker.onActivityVisible(miniProgram.appId, this)) {
+                dispatchMiniProgramShow()
+            }
+            suspendedForMiniProgramNavigation = false
+        }
         getActiveBridge()?.let {
-            it.appShow(miniApp.consumePendingAppShowOptions(miniProgram.appId))
             it.pageShow()
         }
     }
 
     override fun onPause() {
         getActiveBridge()?.let {
-            it.appHide()
             it.pageHide()
         }
         super.onPause()
@@ -1608,7 +1622,7 @@ class DiminaActivity : ComponentActivity() {
             activityRegistry.unregister(miniProgram.appId, this)
         }
 
-        releasePageResources()
+        releasePageResources(pageStateTeardownReason)
 
         if (!preserveMiniAppOnDestroy && miniApp.isBridgeListEmpty(miniProgram.appId)) {
             // Clear resources for this specific MiniProgram
@@ -1651,7 +1665,7 @@ class DiminaActivity : ComponentActivity() {
                 },
                 onCloseClick = {
                     showMiniProgramMenu.value = false
-                    closeMiniProgram()
+                    exitMiniProgram()
                 },
                 onDismiss = {
                     showMiniProgramMenu.value = false
@@ -1854,7 +1868,7 @@ class DiminaActivity : ComponentActivity() {
                     onMoreClick = {
                         showMiniProgramMenu.value = true
                     },
-                    onCloseClick = { closeMiniProgram() },
+                    onCloseClick = { exitMiniProgram() },
                     modifier = Modifier
                         .align(Alignment.TopEnd)
                         .padding(
@@ -1869,13 +1883,21 @@ class DiminaActivity : ComponentActivity() {
 
     private fun closeMiniProgram() {
         activityRegistry.closeAll(miniProgram.appId) { activity ->
+            // 退出对齐微信的「小程序切入后台」：只派发 App.onHide，整栈页面都不收 onUnload。
+            activity.pageStateTeardownReason = PageStateTeardown.EXIT
             activity.finish()
         }
     }
 
     /** Opens a resolved bundled mini program as a new root above this one. */
     fun navigateToMiniProgram(target: MiniProgram) {
-        miniApp.openApp(this, target)
+        suspendForMiniProgramNavigation()
+        try {
+            miniApp.openApp(this, target)
+        } catch (error: Exception) {
+            resumeAfterMiniProgramNavigationFailure()
+            throw error
+        }
     }
 
     /**
@@ -1884,6 +1906,7 @@ class DiminaActivity : ComponentActivity() {
      */
     fun navigateBackMiniProgram(extraData: JSONObject): Boolean {
         if (!queueOpenerReturn(extraData)) return false
+        suspendForMiniProgramNavigation()
         closeMiniProgram()
         return true
     }
@@ -1892,8 +1915,71 @@ class DiminaActivity : ComponentActivity() {
         // exit has no return extraData, but revealing a live opener is still scene 1038
         // ("returned from another mini program"). Queue it before closing this Activity;
         // MiniApp consumes the payload exactly once when the opener resumes.
-        queueOpenerReturn(extraData = null)
+        if (queueOpenerReturn(extraData = null)) {
+            suspendForMiniProgramNavigation()
+        }
         closeMiniProgram()
+    }
+
+    private fun suspendForMiniProgramNavigation() {
+        if (suspendedForMiniProgramNavigation) return
+        getActiveBridge()?.pageHide()
+        if (visibilityTracker.onMiniProgramHidden(miniProgram.appId)) {
+            dispatchMiniProgramHide()
+        }
+        suspendedForMiniProgramNavigation = true
+    }
+
+    private fun resumeAfterMiniProgramNavigationFailure() {
+        if (!suspendedForMiniProgramNavigation) return
+        if (visibilityTracker.onActivityVisible(miniProgram.appId, this)) {
+            dispatchMiniProgramShow()
+        }
+        getActiveBridge()?.pageShow()
+        suspendedForMiniProgramNavigation = false
+    }
+
+    /**
+     * [MiniApp.getJsCore] would synchronously unzip and evaluate service.js on whatever thread
+     * calls it; onStart/onStop run on the main thread, so this only forwards to an instance that
+     * `initialize()` has already bootstrapped off it. A recreate that bypasses [MiniApp.openApp]
+     * (a config change, or a process-death restore from Recents) can call this before that
+     * bootstrap lands - the pending intent is not lost, it is left for
+     * [reconcileAppVisibilityWithCore] to replay once a real JsCore exists.
+     */
+    private fun dispatchMiniProgramShow() {
+        val jsCore = miniApp.peekJsCore(miniProgram.appId)
+        if (jsCore != null) {
+            val showOptions = miniApp.consumePendingAppShowOptions(miniProgram.appId)?.apply {
+                getActiveBridge()?.options?.pathInfo?.let { pathInfo ->
+                    if (!has("pagePath")) put("pagePath", pathInfo.pagePath)
+                    if (!has("query")) put("query", pathInfo.query ?: JSONObject())
+                }
+            }
+            jsCore.appShow(showOptions)
+        }
+        com.didi.dimina.api.network.WebSocketManager.shared.setBackgrounded(miniProgram.appId, false)
+    }
+
+    private fun dispatchMiniProgramHide() {
+        miniApp.peekJsCore(miniProgram.appId)?.appHide()
+        com.didi.dimina.api.network.WebSocketManager.shared.setBackgrounded(miniProgram.appId, true)
+    }
+
+    /**
+     * A freshly-created JsCore's AppVisibilityLedger defaults to "shown" - the service-side App's
+     * own construction already fires an implicit onShow. [dispatchMiniProgramShow]/
+     * [dispatchMiniProgramHide] may have run earlier in onStart/onStop with no JsCore to forward
+     * to yet; reconcile that default against the tracker's live truth once this Activity's
+     * `initialize()` hands a real JsCore to its Bridge. Idempotent when the JsCore already
+     * existed and was already current.
+     */
+    private fun reconcileAppVisibilityWithCore() {
+        if (visibilityTracker.isForeground(miniProgram.appId)) {
+            dispatchMiniProgramShow()
+        } else {
+            dispatchMiniProgramHide()
+        }
     }
 
     private fun queueOpenerReturn(extraData: JSONObject?): Boolean {

--- a/android/dimina/src/main/kotlin/com/didi/dimina/ui/container/MiniProgramVisibilityTracker.kt
+++ b/android/dimina/src/main/kotlin/com/didi/dimina/ui/container/MiniProgramVisibilityTracker.kt
@@ -42,6 +42,10 @@ internal class MiniProgramVisibilityTracker<T> {
         return true
     }
 
+    /** Records an explicit whole-app transition, independent of Activity callback interleaving. */
+    @Synchronized
+    fun onMiniProgramHidden(appId: String): Boolean = visibleActivities.remove(appId) != null
+
     /** [appId] 名下当前是否还有可见的 Activity。 */
     @Synchronized
     fun isForeground(appId: String): Boolean = !visibleActivities[appId].isNullOrEmpty()

--- a/android/dimina/src/test/java/com/didi/dimina/api/route/RouteApiTest.kt
+++ b/android/dimina/src/test/java/com/didi/dimina/api/route/RouteApiTest.kt
@@ -29,6 +29,34 @@ class RouteApiTest {
     }
 
     @Test
+    fun `a failed operation neither escapes the runtime queue nor holds the guard`() {
+        val guard = MiniProgramOperationGuard()
+
+        val result = miniProgramOperationResult("navigateToMiniProgram", guard) {
+            throw IllegalStateException("activity refused to start")
+        }
+        // afterComplete runs on the JS runtime queue, where an exception has nowhere to go but
+        // through the message loop.
+        result.afterComplete?.invoke()
+
+        assertEquals("navigateToMiniProgram:ok", result.value.getString("errMsg"))
+        assertTrue("the guard must admit a retry", guard.tryBegin())
+    }
+
+    @Test
+    fun `a second operation is rejected while one is still running`() {
+        val guard = MiniProgramOperationGuard()
+
+        val first = miniProgramOperationResult("navigateToMiniProgram", guard) {}
+        val second = miniProgramOperationResult("exitMiniProgram", guard) {}
+
+        assertEquals("navigateToMiniProgram:ok", first.value.getString("errMsg"))
+        val rejection = second.value.getString("errMsg")
+        assertTrue(rejection, rejection.startsWith("exitMiniProgram:fail"))
+        assertTrue(rejection, rejection.contains("another mini program operation is in progress"))
+    }
+
+    @Test
     fun `mini program results carry the same errMsg into complete`() {
         val success = miniProgramSuccessResult("exitMiniProgram") {}
         val failure = miniProgramErrorResult("restartMiniProgram", "path is required")

--- a/android/dimina/src/test/java/com/didi/dimina/core/AppVisibilityLedgerTest.kt
+++ b/android/dimina/src/test/java/com/didi/dimina/core/AppVisibilityLedgerTest.kt
@@ -1,0 +1,56 @@
+package com.didi.dimina.core
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AppVisibilityLedgerTest {
+
+    @Test
+    fun `cold start uses the App show emitted while the service creates the app`() {
+        val ledger = AppVisibilityLedger()
+
+        assertNull(ledger.onShow())
+        assertNull(ledger.onServiceReady())
+    }
+
+    @Test
+    fun `hide before service readiness is delivered after the implicit initial show`() {
+        val ledger = AppVisibilityLedger()
+
+        assertNull(ledger.onShow())
+        assertNull(ledger.onHide())
+        val delivery = ledger.onServiceReady()!!
+
+        assertFalse(delivery.visible)
+        assertNull(delivery.options)
+    }
+
+    @Test
+    fun `return show is retained with its options and duplicate directions are suppressed`() {
+        val ledger = AppVisibilityLedger()
+        ledger.onServiceReady()
+
+        assertFalse(ledger.onHide()!!.visible)
+        assertNull(ledger.onHide())
+
+        val delivery = ledger.onShow(JSONObject("""{"scene":1038}"""))!!
+        assertTrue(delivery.visible)
+        assertEquals(1038, delivery.options!!.getInt("scene"))
+        assertNull(ledger.onShow())
+    }
+
+    @Test
+    fun `reset removes readiness and pending visibility from the old runtime`() {
+        val ledger = AppVisibilityLedger()
+        ledger.onServiceReady()
+        ledger.onHide()
+        ledger.reset()
+
+        assertNull(ledger.onShow())
+        assertNull(ledger.onServiceReady())
+    }
+}

--- a/android/dimina/src/test/java/com/didi/dimina/core/PageVisibilityLedgerTest.kt
+++ b/android/dimina/src/test/java/com/didi/dimina/core/PageVisibilityLedgerTest.kt
@@ -1,0 +1,145 @@
+package com.didi.dimina.core
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class PageVisibilityLedgerTest {
+
+    private val delivered = mutableListOf<PageVisibilityDelivery>()
+    private val ledger = PageVisibilityLedger { delivered.add(it) }
+
+    @Test
+    fun `onStart defaults to shown when nothing else has expressed an intent`() {
+        ledger.onStart()
+        assertEquals(emptyList<PageVisibilityDelivery>(), delivered)
+
+        ledger.onResourceReady()
+
+        assertEquals(listOf(PageVisibilityDelivery.SHOW), delivered)
+    }
+
+    @Test
+    fun `onStart honors an explicit visibility over the default`() {
+        ledger.onStart(explicitVisible = false)
+        ledger.onResourceReady()
+
+        assertEquals(emptyList<PageVisibilityDelivery>(), delivered)
+    }
+
+    @Test
+    fun `an intent recorded before start is not overwritten by the default`() {
+        ledger.onHide()
+        ledger.onStart()
+        ledger.onResourceReady()
+
+        assertEquals(emptyList<PageVisibilityDelivery>(), delivered)
+    }
+
+    @Test
+    fun `a page that never became visible does not owe a pageHide once ready`() {
+        ledger.onHide()
+        ledger.onResourceReady()
+        ledger.onHide()
+
+        assertEquals(emptyList<PageVisibilityDelivery>(), delivered)
+    }
+
+    @Test
+    fun `only the latest direction before ready is delivered`() {
+        ledger.onStart()
+        ledger.onHide()
+        ledger.onShow()
+        ledger.onResourceReady()
+
+        assertEquals(listOf(PageVisibilityDelivery.SHOW), delivered)
+    }
+
+    @Test
+    fun `duplicate directions after becoming visible are suppressed`() {
+        ledger.onStart()
+        ledger.onResourceReady()
+
+        ledger.onHide()
+        ledger.onHide()
+        ledger.onShow()
+        ledger.onShow()
+
+        assertEquals(
+            listOf(
+                PageVisibilityDelivery.SHOW,
+                PageVisibilityDelivery.HIDE,
+                PageVisibilityDelivery.SHOW,
+            ),
+            delivered,
+        )
+    }
+
+    @Test
+    fun `onResourceReady only flushes once per generation`() {
+        ledger.onStart()
+        ledger.onResourceReady()
+        ledger.onResourceReady()
+
+        assertEquals(listOf(PageVisibilityDelivery.SHOW), delivered)
+    }
+
+    @Test
+    fun `reset drops readiness and any recorded intent`() {
+        ledger.onResourceReady()
+        ledger.onHide()
+        ledger.reset()
+
+        ledger.onHide()
+        ledger.onResourceReady()
+
+        assertEquals(emptyList<PageVisibilityDelivery>(), delivered)
+    }
+
+    /**
+     * Readiness arrives on the WebView's JavaBridge thread while show/hide intents arrive on the
+     * main thread, so a hide can be raised while the show it supersedes is still on its way to the
+     * service. The later transition must not overtake it: the service would be left visible while
+     * the ledger records hidden, and no later intent can correct that, because the ledger
+     * suppresses the direction it believes was already sent.
+     *
+     * The show delivery is held mid-flight while a second thread hides the page. Reaching the
+     * service is recorded when the delivery returns, so a ledger that lets go of its state before
+     * sending shows up as a HIDE arriving ahead of the SHOW it was meant to supersede.
+     */
+    @Test
+    fun `a transition raised mid-delivery cannot overtake the delivery in flight`() {
+        val arrived = Collections.synchronizedList(mutableListOf<PageVisibilityDelivery>())
+        val showInFlight = CountDownLatch(1)
+        val releaseShow = CountDownLatch(1)
+        val raced = PageVisibilityLedger { delivery ->
+            if (delivery == PageVisibilityDelivery.SHOW) {
+                showInFlight.countDown()
+                check(releaseShow.await(5, TimeUnit.SECONDS)) { "show delivery was never released" }
+            }
+            arrived.add(delivery)
+        }
+        raced.onStart()
+
+        val ready = Thread { raced.onResourceReady() }
+        ready.start()
+        check(showInFlight.await(5, TimeUnit.SECONDS)) { "show was never delivered" }
+
+        val hide = Thread { raced.onHide() }
+        hide.start()
+        // The hide must not reach the service while the show is still in flight.
+        hide.join(300)
+        assertEquals(emptyList<PageVisibilityDelivery>(), arrived.toList())
+
+        releaseShow.countDown()
+        ready.join(5_000)
+        hide.join(5_000)
+
+        assertEquals(
+            listOf(PageVisibilityDelivery.SHOW, PageVisibilityDelivery.HIDE),
+            arrived.toList(),
+        )
+    }
+}

--- a/android/dimina/src/test/java/com/didi/dimina/ui/container/DiminaActivityBackgroundHookTest.kt
+++ b/android/dimina/src/test/java/com/didi/dimina/ui/container/DiminaActivityBackgroundHookTest.kt
@@ -34,10 +34,10 @@ class DiminaActivityBackgroundHookTest {
         found.readText()
     }
 
-    /** The brace-matched body of `override fun [name]`, or a failure if that override is gone. */
+    /** The brace-matched body of `fun [name]`, or a failure if that declaration is gone. */
     private fun bodyOf(name: String): String {
-        val signature = Regex("""\n\s*override fun $name\(""").find(source)
-            ?: throw AssertionError("DiminaActivity no longer declares `override fun $name(`")
+        val signature = Regex("""\n\s*(?:private\s+)?(?:override\s+)?fun $name\(""").find(source)
+            ?: throw AssertionError("DiminaActivity no longer declares `fun $name(`")
         val open = source.indexOf('{', signature.range.last)
         if (open < 0) throw AssertionError("no body found for `$name`")
 
@@ -65,7 +65,7 @@ class DiminaActivityBackgroundHookTest {
         )
         assertTrue(
             "onStart must report the mini program back to the *foreground*; found:\n$onStart",
-            Regex("""setBackgrounded\(\s*miniProgram\.appId\s*,\s*false\s*\)""").containsMatchIn(onStart),
+            onStart.contains("dispatchMiniProgramShow"),
         )
 
         val onStop = bodyOf("onStop")
@@ -76,40 +76,165 @@ class DiminaActivityBackgroundHookTest {
         )
         assertTrue(
             "onStop must report the mini program to the *background*; found:\n$onStop",
-            Regex("""setBackgrounded\(\s*miniProgram\.appId\s*,\s*true\s*\)""").containsMatchIn(onStop),
+            onStop.contains("dispatchMiniProgramHide"),
         )
     }
 
     @Test
-    fun `onResume and onPause do not touch the background verdict`() {
-        for (name in listOf("onResume", "onPause")) {
-            val body = bodyOf(name)
-            assertFalse(
-                "$name must not drive the WebSocket background verdict: a permission dialog, a system share " +
-                    "sheet and a dialog-style picker all pause the activity while the mini program is still on " +
-                    "screen, so a user who lingers past the background grace period would lose every connection",
-                body.contains("setBackgrounded"),
-            )
-            assertFalse(
-                "$name must not consult the visibility tracker either - the tracker's accounting only lines up " +
-                    "when it is fed from onStart/onStop",
-                body.contains("visibilityTracker"),
-            )
-        }
+    fun `onPause does not change app visibility and onResume only repairs a failed cross app launch`() {
+        val onPause = bodyOf("onPause")
+        assertFalse(onPause.contains("setBackgrounded"))
+        assertFalse(onPause.contains("visibilityTracker"))
+
+        val onResume = bodyOf("onResume")
+        assertFalse(onResume.contains("setBackgrounded"))
+        assertTrue(onResume.contains("suspendedForMiniProgramNavigation"))
+        assertTrue(onResume.contains("visibilityTracker.onActivityVisible"))
     }
 
     @Test
-    fun `onStart and onStop are the only callers of setBackgrounded`() {
+    fun `page and app visibility follow their distinct Android lifecycle facts`() {
+        val onStart = bodyOf("onStart")
+        assertTrue(onStart.contains("dispatchMiniProgramShow"))
+        assertFalse(onStart.contains(".pageShow("))
+
+        val onResume = bodyOf("onResume")
+        assertTrue(onResume.contains(".pageShow("))
+        assertFalse(onResume.contains(".appShow("))
+        assertFalse(onResume.contains("consumePendingAppShowOptions"))
+
+        val onPause = bodyOf("onPause")
+        assertTrue(onPause.contains(".pageHide("))
+        assertFalse(onPause.contains(".appHide("))
+
+        val onStop = bodyOf("onStop")
+        assertTrue(onStop.contains("dispatchMiniProgramHide"))
+        assertFalse(onStop.contains(".pageHide("))
+
+        val appShow = bodyOf("dispatchMiniProgramShow")
+        assertTrue(appShow.contains(".appShow("))
+        assertTrue(appShow.contains("consumePendingAppShowOptions"))
+        assertTrue(
+            "dispatchMiniProgramShow must look up the JsCore without creating one: getJsCore() " +
+                "would synchronously unzip and evaluate service.js on the calling (main) thread, and " +
+                "leaves a permanently broken instance behind for a Context-less caller. Found:\n$appShow",
+            appShow.contains("peekJsCore"),
+        )
+        assertFalse(
+            "dispatchMiniProgramShow must not call the creating getJsCore()",
+            appShow.contains("getJsCore"),
+        )
+        assertTrue(
+            "dispatchMiniProgramShow must report the mini program to the *foreground* verdict; " +
+                "found:\n$appShow",
+            Regex("""setBackgrounded\(\s*miniProgram\.appId\s*,\s*false\s*\)""").containsMatchIn(appShow),
+        )
+
+        val appHide = bodyOf("dispatchMiniProgramHide")
+        assertTrue(appHide.contains(".appHide("))
+        assertTrue(
+            "dispatchMiniProgramHide must look up the JsCore without creating one",
+            appHide.contains("peekJsCore"),
+        )
+        assertFalse(
+            "dispatchMiniProgramHide must not call the creating getJsCore()",
+            appHide.contains("getJsCore"),
+        )
+        assertTrue(
+            "dispatchMiniProgramHide must report the mini program to the *background* verdict; " +
+                "found:\n$appHide",
+            Regex("""setBackgrounded\(\s*miniProgram\.appId\s*,\s*true\s*\)""").containsMatchIn(appHide),
+        )
+    }
+
+    @Test
+    fun `a JsCore created without a Context is never left permanently uninitialized`() {
+        // dispatchMiniProgramShow/Hide run off onStart/onStop on the main thread and must not pay
+        // for service.js bootstrap there; but a config-change or process-death recreate that
+        // bypasses MiniApp#openApp has no other JsCore yet when onStart fires. Reconciliation must
+        // exist and must be reachable from wherever a real, Context-bearing JsCore is first handed
+        // to a Bridge - otherwise the visibility intent recorded on the tracker while there was no
+        // JsCore is silently dropped forever.
+        val createBridge = bodyOf("createBridge")
+        assertTrue(
+            "createBridge must reconcile app visibility once a real (Context-bearing) JsCore " +
+                "exists for this appId; found:\n$createBridge",
+            createBridge.contains("reconcileAppVisibilityWithCore"),
+        )
+
+        val reconcile = bodyOf("reconcileAppVisibilityWithCore")
+        assertTrue(reconcile.contains("visibilityTracker.isForeground"))
+        assertTrue(reconcile.contains("dispatchMiniProgramShow"))
+        assertTrue(reconcile.contains("dispatchMiniProgramHide"))
+    }
+
+    @Test
+    fun `app visibility dispatchers are the only callers of setBackgrounded`() {
         val calls = Regex("""setBackgrounded""")
-        val inHooks = calls.findAll(bodyOf("onStart") + bodyOf("onStop")).count()
+        val inHooks = calls.findAll(
+            bodyOf("dispatchMiniProgramShow") + bodyOf("dispatchMiniProgramHide"),
+        ).count()
         val inWholeFile = calls.findAll(source).count()
 
         assertEquals(
             "the mini program's foreground/background state has exactly one source of truth. Something " +
-                "outside onStart/onStop now calls setBackgrounded; if that caller is genuinely needed, it " +
+            "outside the app visibility dispatchers now calls setBackgrounded; if that caller is genuinely needed, it " +
                 "has to be reconciled with the tracker's accounting rather than added alongside it.",
             inHooks,
             inWholeFile,
         )
+    }
+
+    @Test
+    fun `native close affordances go through exitMiniProgram so a live opener is restored`() {
+        // closeMiniProgram is the raw "finish every Activity of this appId" primitive: it neither
+        // queues the opener's scene 1038 payload nor runs the page-hide-before-app-hide ordering.
+        // The capsule "x" and the menu's 关闭小程序 are the *only* ways a user closes a mini program
+        // that was opened by another one, so wiring either of them straight to the primitive loses
+        // the opener restoration that navigateBackMiniProgram gets for free - a real-device
+        // reproduction showed the opener resuming with an empty appShow body and scene 1001.
+        val content = bodyOf("DiminaContent")
+        assertTrue(
+            "the close affordances in DiminaContent must route through exitMiniProgram; found:\n$content",
+            content.contains("exitMiniProgram()"),
+        )
+        assertFalse(
+            "no UI affordance may call the raw closeMiniProgram(): it skips the opener return " +
+                "payload and the suspension ordering. Route it through exitMiniProgram() instead.",
+            content.contains("closeMiniProgram("),
+        )
+
+        // Pins the same invariant file-wide, so the check survives the handlers moving out of
+        // DiminaContent: the primitive stays reachable only from the two functions that first give
+        // a live opener its scene 1038 payload.
+        val callSites = Regex("""(?<!fun )closeMiniProgram\(\)""")
+        val inRouters = callSites.findAll(
+            bodyOf("navigateBackMiniProgram") + bodyOf("exitMiniProgram"),
+        ).count()
+        assertEquals(
+            "closeMiniProgram() gained a caller outside navigateBackMiniProgram/exitMiniProgram. " +
+                "A new caller has to decide what happens to a live opener rather than silently " +
+                "dropping it.",
+            inRouters,
+            callSites.findAll(source).count(),
+        )
+
+        val exit = bodyOf("exitMiniProgram")
+        assertTrue(
+            "exitMiniProgram must queue the opener's return payload before closing; found:\n$exit",
+            exit.indexOf("queueOpenerReturn") in 0 until exit.indexOf("closeMiniProgram("),
+        )
+    }
+
+    @Test
+    fun `cross mini program suspension dispatches page hide before app hide`() {
+        val suspend = bodyOf("suspendForMiniProgramNavigation")
+        val pageHide = suspend.indexOf(".pageHide(")
+        val appHide = suspend.indexOf("dispatchMiniProgramHide")
+
+        assertTrue(pageHide >= 0)
+        assertTrue(appHide > pageHide)
+        assertTrue(bodyOf("navigateToMiniProgram").contains("suspendForMiniProgramNavigation"))
+        assertTrue(bodyOf("navigateBackMiniProgram").contains("suspendForMiniProgramNavigation"))
     }
 }

--- a/android/dimina/src/test/java/com/didi/dimina/ui/container/MiniProgramVisibilityTrackerTest.kt
+++ b/android/dimina/src/test/java/com/didi/dimina/ui/container/MiniProgramVisibilityTrackerTest.kt
@@ -106,4 +106,17 @@ class MiniProgramVisibilityTrackerTest {
         assertFalse(tracker.onActivityHidden("never-opened", "page"))
         assertFalse("querying an unknown appId must not register it", tracker.isForeground("never-opened"))
     }
+
+    @Test
+    fun `an explicit cross mini program transition hides the whole source app exactly once`() {
+        val tracker = MiniProgramVisibilityTracker<String>()
+        tracker.onActivityVisible("source", "page-1")
+        tracker.onActivityVisible("source", "page-2")
+
+        assertTrue(tracker.onMiniProgramHidden("source"))
+        assertFalse(tracker.isForeground("source"))
+        assertFalse(tracker.onActivityHidden("source", "page-1"))
+        assertFalse(tracker.onActivityHidden("source", "page-2"))
+        assertFalse(tracker.onMiniProgramHidden("source"))
+    }
 }

--- a/android/dimina/src/test/java/com/didi/dimina/ui/container/PageStateTeardownReasonTest.kt
+++ b/android/dimina/src/test/java/com/didi/dimina/ui/container/PageStateTeardownReasonTest.kt
@@ -1,0 +1,141 @@
+package com.didi.dimina.ui.container
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Pins *which* page teardowns dispatch Page.onUnload.
+ *
+ * 微信的 unloadPage 只由路由事件驱动（reLaunch/redirectTo/navigateBack/switchTab）；退出小程序
+ * 走 onAppEnterBackground，只派发 App.onHide，页面不收 onUnload。Android 上每个页面都是一个
+ * Activity，所以退出和 navigateBack 共用 onDestroy -> releasePageResources -> Bridge.destroy 这
+ * 一条销毁链，唯一的区别就是关栈的一方在 finish() 前留下的 [com.didi.dimina.core.PageStateTeardown]。
+ * 把它接错的两个方向都是真缺陷：退出时多发 onUnload（三端不一致），或路由时漏发 onUnload（页面
+ * 永远收不到卸载，比前者更糟），所以下面两个方向各有断言。
+ *
+ * 断言读源码文本。真正驱动一个 Activity 走完 onDestroy 需要 Android 运行时，本模块的单元测试没有
+ * 也不能在不改构建脚本的前提下拥有。每个查找在找不到目标时抛错，重命名或抽取会让这个测试失败，而
+ * 不是悄悄变成空断言。
+ */
+class PageStateTeardownReasonTest {
+
+    private fun sourceOf(relativePath: String): String {
+        val candidates = listOf(relativePath, "dimina/$relativePath").map(::File)
+        val found = candidates.firstOrNull(File::isFile)
+            ?: throw AssertionError(
+                "$relativePath not found from working directory ${File(".").absolutePath}; " +
+                    "tried ${candidates.map(File::getPath)}. Fix the path rather than deleting this " +
+                    "test - it is the only thing holding the exit path off Page.onUnload.",
+            )
+        return found.readText()
+    }
+
+    private val activitySource: String by lazy {
+        sourceOf("src/main/kotlin/com/didi/dimina/ui/container/DiminaActivity.kt")
+    }
+
+    private val bridgeSource: String by lazy {
+        sourceOf("src/main/kotlin/com/didi/dimina/core/Bridge.kt")
+    }
+
+    /** The brace-matched body of `fun [name]` in [source], or a failure if that declaration is gone. */
+    private fun bodyOf(source: String, name: String): String {
+        val signature = Regex("""\n\s*(?:private\s+)?(?:override\s+)?fun $name\(""").find(source)
+            ?: throw AssertionError("no `fun $name(` declaration left to check")
+        val open = source.indexOf('{', signature.range.last)
+        if (open < 0) throw AssertionError("no body found for `$name`")
+
+        var depth = 0
+        for (i in open until source.length) {
+            when (source[i]) {
+                '{' -> depth++
+                '}' -> if (--depth == 0) return source.substring(open + 1, i)
+            }
+        }
+        throw AssertionError("unbalanced braces while reading the body of `$name`")
+    }
+
+    @Test
+    fun `Bridge dispatches pageUnload only for a routing teardown`() {
+        val destroy = bodyOf(bridgeSource, "destroy")
+        val unloadLine = destroy.lineSequence().firstOrNull { it.contains("\"pageUnload\"") }
+            ?: throw AssertionError("Bridge.destroy no longer posts pageUnload at all:\n$destroy")
+        val guard = destroy.lineSequence()
+            .takeWhile { !it.contains("\"pageUnload\"") }
+            .last { it.contains("if (") }
+        assertTrue(
+            "pageUnload must be gated on the routing reason; an unguarded post puts Android back " +
+                "out of step with iOS on every mini program exit. Guard found:\n$guard\n$unloadLine",
+            guard.contains("reason == PageStateTeardown.ROUTING"),
+        )
+    }
+
+    @Test
+    fun `exiting the mini program marks the whole stack as an exit teardown`() {
+        val closeMiniProgram = bodyOf(activitySource, "closeMiniProgram")
+        assertTrue(
+            "closeMiniProgram is the single entry every exit funnels through (capsule close, menu " +
+                "close, wx.exitMiniProgram, wx.navigateBackMiniProgram). It must stamp each Activity " +
+                "before finish(), otherwise onDestroy falls back to the routing default and the " +
+                "exiting pages get onUnload. Found:\n$closeMiniProgram",
+            closeMiniProgram.contains("pageStateTeardownReason = PageStateTeardown.EXIT"),
+        )
+        assertTrue(
+            "the stamp must land before finish(); afterwards the Activity is already tearing down",
+            closeMiniProgram.indexOf("PageStateTeardown.EXIT") <
+                closeMiniProgram.indexOf("finish()"),
+        )
+    }
+
+    @Test
+    fun `a cold restart is an exit teardown too`() {
+        val prepare = bodyOf(activitySource, "prepareForColdRestart")
+        assertTrue(
+            "restart/re-enter/applyUpdate destroy the whole runtime and build a new one, so they " +
+                "are exit-shaped rather than routing. Found:\n$prepare",
+            prepare.contains("releasePageResources(PageStateTeardown.EXIT)"),
+        )
+    }
+
+    @Test
+    fun `onDestroy carries the reason the closer left instead of hard-coding one`() {
+        val onDestroy = bodyOf(activitySource, "onDestroy")
+        assertTrue(
+            "onDestroy must forward the recorded reason; hard-coding either value collapses the " +
+                "distinction it exists for. Found:\n$onDestroy",
+            onDestroy.contains("releasePageResources(pageStateTeardownReason)"),
+        )
+    }
+
+    @Test
+    fun `routing teardowns keep dispatching onUnload`() {
+        // The reverse mistake: stamping EXIT on a route would silently stop every navigateBack,
+        // reLaunch and switchTab from unloading its page. These three all reach onDestroy or
+        // Bridge.destroy through the routing default, so none of them may stamp EXIT.
+        val relaunchStack = bodyOf(activitySource, "relaunchStack")
+        assertFalse(
+            "wx.reLaunch is a routing event - its pages must still receive onUnload. Found:\n$relaunchStack",
+            relaunchStack.contains("PageStateTeardown.EXIT"),
+        )
+        val switchTabInRoot = bodyOf(activitySource, "switchTabInRoot")
+        assertFalse(
+            "wx.switchTab is a routing event - the tab it replaces must still receive onUnload. " +
+                "Found:\n$switchTabInRoot",
+            switchTabInRoot.contains("PageStateTeardown.EXIT"),
+        )
+        val switchTab = bodyOf(activitySource, "switchTab")
+        assertFalse(
+            "switchTab also closes the non-tab pages stacked above the root; those are routed away, " +
+                "not exited. Found:\n$switchTab",
+            switchTab.contains("PageStateTeardown.EXIT"),
+        )
+        val updatePath = bodyOf(activitySource, "updatePath")
+        assertFalse(
+            "wx.redirectTo replaces the page in place - the old one must still receive onUnload. " +
+                "Found:\n$updatePath",
+            updatePath.contains("PageStateTeardown.EXIT"),
+        )
+    }
+}

--- a/fe/packages/container-sdk/__tests__/bridge-resource-loading.spec.ts
+++ b/fe/packages/container-sdk/__tests__/bridge-resource-loading.spec.ts
@@ -50,7 +50,7 @@ describe('Bridge resource loading protocol', () => {
 		])
 	})
 
-	it('keeps only the latest queued visibility and suppresses duplicate notifications', () => {
+	it('suppresses duplicate visibility notifications after the page becomes visible', () => {
 		const jscore = { postMessage: vi.fn(), notifyServiceReady: vi.fn() }
 		const bridge = createBridge({
 			jscore,
@@ -62,7 +62,6 @@ describe('Bridge resource loading protocol', () => {
 		bridge.resourceLoadId = 'load-hidden'
 
 		bridge.pageShow()
-		bridge.pageHide()
 		bridge.messageInvoke('service', {
 			type: 'serviceResourceLoaded',
 			target: 'service',
@@ -74,14 +73,16 @@ describe('Bridge resource loading protocol', () => {
 			body: { bridgeId: bridge.id, resourceLoadId: bridge.resourceLoadId },
 		})
 		bridge.pageHide()
+		bridge.pageHide()
 
 		expect(jscore.postMessage.mock.calls.map(([message]) => message.type)).toEqual([
 			'resourceLoaded',
+			'pageShow',
 			'pageHide',
 		])
 	})
 
-	it('does not overwrite an early pageHide when start uses its default visibility', () => {
+	it('does not emit pageHide for a page that never became visible', () => {
 		const jscore = { postMessage: vi.fn(), notifyServiceReady: vi.fn() }
 		const bridge = createBridge({
 			jscore,
@@ -118,8 +119,8 @@ describe('Bridge resource loading protocol', () => {
 		expect(jscore.postMessage.mock.calls.map(([message]) => message.type)).toEqual([
 			'loadResource',
 			'resourceLoaded',
-			'pageHide',
 		])
+		expect(bridge.sentPageVisible).toBe(false)
 	})
 
 	it('uses the per-app resource base for both render and service loaders', () => {

--- a/fe/packages/container-sdk/__tests__/mini-program-navigation.spec.ts
+++ b/fe/packages/container-sdk/__tests__/mini-program-navigation.spec.ts
@@ -34,6 +34,19 @@ async function markTopBridgeReady(app: MiniApp): Promise<void> {
 	})
 }
 
+async function markTopBridgeServiceReady(app: MiniApp): Promise<void> {
+	await vi.waitFor(() => expect(app.navigator.top?.resourceLoadId).toEqual(expect.any(String)), { timeout: 8000 })
+	const bridge = app.navigator.top!
+	bridge.messageInvoke('service', {
+		type: 'serviceResourceLoaded',
+		target: 'service',
+		body: {
+			bridgeId: bridge.id,
+			resourceLoadId: bridge.resourceLoadId!,
+		},
+	})
+}
+
 describe('mini program container navigation APIs', () => {
 	let mount: HTMLElement
 
@@ -48,6 +61,7 @@ describe('mini program container navigation APIs', () => {
 		const container = createContainer({ mount })
 		const source = await container.openApp({ appId: 'source-app', path: ENTRY_PAGE_PATH })
 		await waitForReady(source)
+		await markTopBridgeReady(source)
 		source.jscore.notifyServiceReady()
 		const sourceWorker = source.jscore.worker as unknown as FakeWorker
 
@@ -69,6 +83,10 @@ describe('mini program container navigation APIs', () => {
 		expect(source.jscore.worker).toBe(sourceWorker)
 		expect(sourceWorker.terminate).not.toHaveBeenCalled()
 		expect(messagesOfType(sourceWorker, 'appHide')).toHaveLength(1)
+		const sourceHideTypes = sourceWorker.postMessage.mock.calls
+			.map(([message]) => message.type)
+			.filter(type => type === 'pageHide' || type === 'appHide')
+		expect(sourceHideTypes).toEqual(['pageHide', 'appHide'])
 		expect(target.opener).toBe(source)
 		expect(loadResource.body).toMatchObject({
 			pagePath: ENTRY_PAGE_PATH,
@@ -82,6 +100,31 @@ describe('mini program container navigation APIs', () => {
 			{ id: 'open-success', args: { errMsg: 'navigateToMiniProgram:ok' } },
 			{ id: 'open-complete', args: { errMsg: 'navigateToMiniProgram:ok' } },
 		])
+	}, 15000)
+
+	it('does not emit a late pageHide after appHide when the source render is still loading', async () => {
+		const container = createContainer({ mount })
+		const source = await container.openApp({ appId: 'pending-source', path: ENTRY_PAGE_PATH })
+		await waitForReady(source)
+		await markTopBridgeServiceReady(source)
+		const sourceBridge = source.navigator.top!
+		const sourceWorker = source.jscore.worker as unknown as FakeWorker
+
+		await source.navigateToMiniProgram({ appId: 'pending-target' })
+		sourceBridge.messageInvoke('render', {
+			type: 'renderResourceLoaded',
+			target: 'service',
+			body: {
+				bridgeId: sourceBridge.id,
+				resourceLoadId: sourceBridge.resourceLoadId!,
+			},
+		})
+
+		const visibilityTypes = sourceWorker.postMessage.mock.calls
+			.map(([message]) => message.type)
+			.filter(type => type === 'pageShow' || type === 'pageHide' || type === 'appHide')
+		expect(visibilityTypes).toEqual(['appHide'])
+		expect(sourceBridge.sentPageVisible).toBe(false)
 	}, 15000)
 
 	it('navigateBackMiniProgram destroys the target and resumes its opener with scene 1038 return data', async () => {
@@ -122,10 +165,10 @@ describe('mini program container navigation APIs', () => {
 			{ id: 'back-complete', args: { errMsg: 'navigateBackMiniProgram:ok' } },
 		])
 		expect(messagesOfType(targetWorker, 'flushCallbacks')).toHaveLength(1)
-		expect(messagesOfType(targetWorker, 'pageUnload')).toHaveLength(1)
+		// 退出不是路由：页面静默回收，只有 App.onHide，不发 Page.onUnload。
+		expect(messagesOfType(targetWorker, 'pageUnload')).toHaveLength(0)
 		const targetMessageTypes = targetWorker.postMessage.mock.calls.map(([message]) => message.type)
-		expect(targetMessageTypes.indexOf('triggerCallback')).toBeLessThan(targetMessageTypes.indexOf('pageUnload'))
-		expect(targetMessageTypes.indexOf('pageUnload')).toBeLessThan(targetMessageTypes.indexOf('flushCallbacks'))
+		expect(targetMessageTypes.indexOf('triggerCallback')).toBeLessThan(targetMessageTypes.indexOf('flushCallbacks'))
 	}, 20000)
 
 	it('exitMiniProgram runs callbacks before terminating and removes the current runtime', async () => {
@@ -144,10 +187,10 @@ describe('mini program container navigation APIs', () => {
 			{ id: 'exit-complete', args: { errMsg: 'exitMiniProgram:ok' } },
 		])
 		expect(messagesOfType(worker, 'flushCallbacks')).toHaveLength(1)
-		expect(messagesOfType(worker, 'pageUnload')).toHaveLength(1)
+		// 退出不是路由：页面静默回收，只有 App.onHide，不发 Page.onUnload。
+		expect(messagesOfType(worker, 'pageUnload')).toHaveLength(0)
 		const messageTypes = worker.postMessage.mock.calls.map(([message]) => message.type)
-		expect(messageTypes.indexOf('triggerCallback')).toBeLessThan(messageTypes.indexOf('pageUnload'))
-		expect(messageTypes.indexOf('pageUnload')).toBeLessThan(messageTypes.indexOf('flushCallbacks'))
+		expect(messageTypes.indexOf('triggerCallback')).toBeLessThan(messageTypes.indexOf('flushCallbacks'))
 		expect(worker.terminate).toHaveBeenCalledTimes(1)
 	}, 15000)
 
@@ -218,10 +261,10 @@ describe('mini program container navigation APIs', () => {
 			{ id: 'restart-complete', args: { errMsg: 'restartMiniProgram:ok' } },
 		])
 		expect(messagesOfType(originalWorker, 'flushCallbacks')).toHaveLength(1)
-		expect(messagesOfType(originalWorker, 'pageUnload')).toHaveLength(1)
+		// 冷重启整体换 runtime，同样不是路由：旧页面静默回收，不发 Page.onUnload。
+		expect(messagesOfType(originalWorker, 'pageUnload')).toHaveLength(0)
 		const originalMessageTypes = originalWorker.postMessage.mock.calls.map(([message]) => message.type)
-		expect(originalMessageTypes.indexOf('triggerCallback')).toBeLessThan(originalMessageTypes.indexOf('pageUnload'))
-		expect(originalMessageTypes.indexOf('pageUnload')).toBeLessThan(originalMessageTypes.indexOf('flushCallbacks'))
+		expect(originalMessageTypes.indexOf('triggerCallback')).toBeLessThan(originalMessageTypes.indexOf('flushCallbacks'))
 		expect(originalWorker.terminate).toHaveBeenCalledTimes(1)
 	}, 15000)
 

--- a/fe/packages/container-sdk/__tests__/page-teardown-reason.spec.ts
+++ b/fe/packages/container-sdk/__tests__/page-teardown-reason.spec.ts
@@ -1,0 +1,79 @@
+import type { MiniApp } from '../src/pages/miniApp/miniApp.js'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createContainer } from '../src/index.js'
+import { ENTRY_PAGE_PATH } from './fixtures/app-config.js'
+import { FakeWorker, resetFakeWorker } from './fixtures/fake-worker.js'
+import { installFetchMock } from './fixtures/mock-fetch.js'
+
+// 微信只在页面真的被路由换掉时才卸载页面；关掉整个小程序走的是切后台那条路，只有
+// App.onHide。销毁 Bridge 这一步两种情况都要做，区别只在要不要派发 Page.onUnload，
+// 所以原因必须由关闭方带下来，不能由销毁点自己猜。Android 见 core/Bridge.kt 的
+// PageStateTeardown，iOS 见 DMPPageStateTeardown。
+
+function messagesOfType(worker: FakeWorker, type: string): Array<Record<string, unknown>> {
+	return worker.postMessage.mock.calls
+		.map(([message]: [Record<string, unknown>]) => message)
+		.filter(message => message.type === type)
+}
+
+async function waitForReady(app: MiniApp): Promise<void> {
+	await vi.waitFor(() => expect(app.appConfig).not.toBeNull(), { timeout: 8000 })
+}
+
+async function markTopBridgeReady(app: MiniApp): Promise<void> {
+	await vi.waitFor(() => expect(app.navigator.top?.resourceLoadId).toEqual(expect.any(String)), { timeout: 8000 })
+	const bridge = app.navigator.top!
+	const body = {
+		bridgeId: bridge.id,
+		resourceLoadId: bridge.resourceLoadId!,
+	}
+	bridge.messageInvoke('service', { type: 'serviceResourceLoaded', target: 'service', body })
+	bridge.messageInvoke('render', { type: 'renderResourceLoaded', target: 'service', body })
+}
+
+describe('page teardown reason decides whether Page.onUnload is dispatched', () => {
+	let mount: HTMLElement
+
+	beforeEach(() => {
+		installFetchMock()
+		resetFakeWorker()
+		mount = document.createElement('div')
+		document.body.appendChild(mount)
+	})
+
+	it('dispatches pageUnload when a route replaces the page', async () => {
+		const container = createContainer({ mount })
+		const app = await container.openApp({ appId: 'teardown-routing', path: ENTRY_PAGE_PATH })
+		await waitForReady(app)
+		await markTopBridgeReady(app)
+		const worker = app.jscore.worker as unknown as FakeWorker
+
+		app.navigator.top!.destroy()
+
+		expect(messagesOfType(worker, 'pageUnload')).toHaveLength(1)
+	}, 15000)
+
+	it('reclaims the page silently when the whole mini program is torn down', async () => {
+		const container = createContainer({ mount })
+		const app = await container.openApp({ appId: 'teardown-exit', path: ENTRY_PAGE_PATH })
+		await waitForReady(app)
+		await markTopBridgeReady(app)
+		const worker = app.jscore.worker as unknown as FakeWorker
+
+		app.navigator.top!.destroy('exit')
+
+		expect(messagesOfType(worker, 'pageUnload')).toHaveLength(0)
+	}, 15000)
+
+	it('reclaims every stack and tab page silently on the exit lifecycle path', async () => {
+		const container = createContainer({ mount })
+		const app = await container.openApp({ appId: 'teardown-exit-all', path: ENTRY_PAGE_PATH })
+		await waitForReady(app)
+		await markTopBridgeReady(app)
+		const worker = app.jscore.worker as unknown as FakeWorker
+
+		app.queueDestructionLifecycle()
+
+		expect(messagesOfType(worker, 'pageUnload')).toHaveLength(0)
+	}, 15000)
+})

--- a/fe/packages/container-sdk/src/core/appManager.ts
+++ b/fe/packages/container-sdk/src/core/appManager.ts
@@ -122,7 +122,8 @@ export class AppManager {
 			const appsToDestroy = [...this.apps.values()].filter(app => app.appId !== appId)
 			for (const app of appsToDestroy) {
 				const currentBridge = app.navigator.popPage()
-				currentBridge?.destroy()
+				// 整个小程序被关掉，不是一次路由：静默回收，不派发 Page.onUnload。
+				currentBridge?.destroy('exit')
 				await dimina.destroyRootView(app) // view.destroy() 内部会把自己从 apps 里移除
 			}
 		}

--- a/fe/packages/container-sdk/src/core/bridge.ts
+++ b/fe/packages/container-sdk/src/core/bridge.ts
@@ -7,6 +7,13 @@ import { uuid } from '../utils/util.js'
 const RESOURCE_READY_TIMEOUT_MS = 15000
 
 /** Bridge.start(options) 的可选启动参数：透传 visible 覆盖 desiredPageVisible 缺省值。 */
+/**
+ * 拆掉页面的两种原因。微信里 unloadPage 只有路由事件（reLaunch/redirectTo/navigateBack/
+ * switchTab）会触发，退出小程序走的是 onAppEnterBackground，只派发 App.onHide，页面不收
+ * onUnload。三端语义一致，Android 见 core/Bridge.kt 的 PageStateTeardown。
+ */
+export type PageStateTeardown = 'routing' | 'exit'
+
 export interface BridgeStartOptions {
 	visible?: boolean
 }
@@ -374,6 +381,10 @@ export class Bridge {
 		) {
 			return
 		}
+		if (!this.desiredPageVisible && this.sentPageVisible === null) {
+			this.sentPageVisible = false
+			return
+		}
 
 		this.jscore.postMessage({
 			type: this.desiredPageVisible ? 'pageShow' : 'pageHide',
@@ -384,7 +395,11 @@ export class Bridge {
 		this.sentPageVisible = this.desiredPageVisible
 	}
 
-	destroy(): void {
+	/**
+	 * @param reason 默认按路由处理：直接销毁一个 Bridge 的调用点全都是路由卸载页面。
+	 * 退出小程序或整体换 runtime 由关闭方显式传 'exit'，那时只静默回收资源。
+	 */
+	destroy(reason: PageStateTeardown = 'routing'): void {
 		const wasResourceLoaded = this.isResourceLoaded()
 		this.#rejectResourceReady(new Error('bridge was destroyed before resources became ready'))
 		this.destroyed = true
@@ -394,7 +409,7 @@ export class Bridge {
 		this.resourceLoadId = null
 		this.desiredPageVisible = null
 		this.sentPageVisible = null
-		if (wasResourceLoaded) {
+		if (wasResourceLoaded && reason === 'routing') {
 			this.jscore.postMessage({
 				type: 'pageUnload',
 				body: {

--- a/fe/packages/container-sdk/src/pages/miniApp/miniApp.ts
+++ b/fe/packages/container-sdk/src/pages/miniApp/miniApp.ts
@@ -1061,15 +1061,15 @@ export class MiniApp {
 	onPresentOut(): void {
 		const currentBridge = this.navigator.top
 
+		currentBridge?.pageHide()
 		this.webSocketManager.onAppHide()
 		this.jscore.appHide()
-		currentBridge?.pageHide()
 	}
 
 	/**
-	 * Queue Page.onUnload for every live stack/tab page before the caller's FIFO callback barrier.
-	 * Bridge destruction does not remove the iframe DOM, so exit animations can still finish while
-	 * the old service runtime drains these terminal lifecycle messages.
+	 * 回收整个小程序的 Bridge 资源，排在调用方的 FIFO 回调 barrier 之前。这条链路只由退出
+	 * 小程序和整体换 runtime 走，不是路由，所以按 'exit' 静默回收，不派发 Page.onUnload——
+	 * 关掉整个小程序在微信里走的是切后台那条路。Bridge 销毁不摘 iframe DOM，退出动画照常播完。
 	 */
 	queueDestructionLifecycle(): void {
 		if (this._destructionLifecycleQueued) {
@@ -1078,7 +1078,7 @@ export class MiniApp {
 		this._destructionLifecycleQueued = true
 		const bridges = new Set([...this.navigator.getStack(), ...this.navigator.getTabBridges()])
 		for (const bridge of bridges) {
-			bridge.destroy()
+			bridge.destroy('exit')
 		}
 	}
 

--- a/harmony/dimina/src/main/ets/Components/DMPCapsuleButton.ets
+++ b/harmony/dimina/src/main/ets/Components/DMPCapsuleButton.ets
@@ -68,7 +68,14 @@ export struct DMPCapsuleButton {
         if (this.onCloseClick) {
           this.onCloseClick()
         } else {
-          DMPAppManager.sharedInstance().getApp(this.appIndex)?.closeDimina()
+          const app = DMPAppManager.sharedInstance().getApp(this.appIndex)
+          if (app) {
+            // Mirrors DMPPageContainer.closeMiniProgram: exitMiniProgram (not
+            // closeDimina directly) restores the opener when one exists.
+            DMPAppManager.sharedInstance().exitMiniProgram(app, async () => {}).catch((error: Error) => {
+              DMPLogger.e(Tags.DMP_PAGE, `capsule close failed: ${error.message}`)
+            })
+          }
         }
       })
     }

--- a/harmony/dimina/src/main/ets/DApp/DMPApp.ets
+++ b/harmony/dimina/src/main/ets/DApp/DMPApp.ets
@@ -27,6 +27,7 @@ import { common } from '@kit.AbilityKit'
 import { DMPNavigatorDelegate } from '../Navigator/DMPNavigatorDelegate'
 import { DMPAppManager } from './DMPAppManager'
 import { DMPNavigatorManager } from '../Navigator/DMPNavigatorManager'
+import { DMPPageStateTeardown } from '../Navigator/DMPPageStateTeardown'
 import { DRouter } from '../Navigator/DRouter'
 import { DMPAppLifecycle } from './DMPAppLifecycle'
 import { DMPDeviceUtil } from '../Utils/DMPDeviceUtils'
@@ -34,6 +35,7 @@ import { DMPRemoteUpdateManager } from '../Bundle/DMPRemoteUpdateManager'
 import { DMPWebSocketManager } from '../Bridges/Network/DMPWebSocketManager'
 import { DMPAppModuleManagerLifecycle } from '../Bridges/DMPAppModuleManagerLifecycle'
 import { DMPAppRuntimeLifecycle } from './utils/DMPAppRuntimeLifecycle'
+import { DMPAppVisibilityLedger } from './utils/DMPAppVisibilityLedger'
 import { CanvasExportJobRegistry } from '../Bridges/CanvasExportJobRegistry'
 export type DMPBundleUpdateCallback = () => void;
 
@@ -56,6 +58,10 @@ export class DMPApp {
   private _mapManager: DMPMapManager = new DMPMapManager(this)
   private _runtimeGeneration: number = 0
   private _runtimeLifecycle: DMPAppRuntimeLifecycle = new DMPAppRuntimeLifecycle()
+  private _visibilityLedger: DMPAppVisibilityLedger = new DMPAppVisibilityLedger()
+  // 宿主后台期间攒下的那一次恢复要带的 enter options，见 [stashMiniProgramShow]。
+  private _pendingShowScene: DMPScene | undefined = undefined
+  private _pendingShowReferrer: DMPMap | undefined = undefined
   private _closeInProgress?: Promise<void>
   private _deferredLaunchConfigs: DMPLaunchConfig[] = []
   private _webViewCachePool: DMPWebViewCachePool = new DMPWebViewCachePool(this)
@@ -204,7 +210,7 @@ export class DMPApp {
     // 层）——不清掉的话它们会在共享 NavPathStack 里永久残留。复用现有的批量关闭能力，不
     // 单独实现一套清栈逻辑
     if (!this.navigatorManager.isEmpty()) {
-      this.navigatorManager.closeAllNavigators(false)
+      this.navigatorManager.closeAllNavigators(DMPPageStateTeardown.Routing, false)
     }
     //为什么延时，因为鸿蒙pop和push 会相互抵消，导致页面不能正常关闭
     setTimeout(() => {
@@ -252,10 +258,12 @@ export class DMPApp {
       // runtime its own one-shot route completion used by restartMiniProgram.
       nextLaunchConfig.completion = config.completion
     }
-    this.notifyMiniProgramHide()
-    this.navigatorManager.closeAllNavigators(false)
-    // pageUnload and any terminal API callback are queued to the Worker. Drain them before
-    // terminating the old runtime; a fixed timeout cannot provide this ordering guarantee.
+    this.notifyRuntimeTeardownHide()
+    // restart 是「关掉再重开」而不是一次路由：上面已经发过 App.onHide，旧运行时紧接着
+    // 整体销毁，所以和退出同源，不补 onUnload。
+    this.navigatorManager.closeAllNavigators(DMPPageStateTeardown.Exit, false)
+    // Terminal API callbacks are queued to the Worker. Drain them before terminating the old
+    // runtime; a fixed timeout cannot provide this ordering guarantee.
     await this._service.flush()
     this.destroyEngine()
     this.resetAndStartDimina(nextLaunchConfig)
@@ -266,7 +274,11 @@ export class DMPApp {
     this.startDimina(DMPContextUtils.getUIAbilityContext(), config);
   }
 
-  private rebuildRuntime() {
+  /**
+   * @param afterExit 小程序已经退出过、这次是重新展示。restart 则是容器留在原地只换运行时，
+   * 两者对「容器当前是否可见」的判断不同，见 DMPAppVisibilityLedger。
+   */
+  private rebuildRuntime(afterExit: boolean = false) {
     this.onUpdateResults = []
     this._runtimeGeneration++
     CanvasExportJobRegistry.activate(this.appConfig.appId, this.canvasExportOwner)
@@ -281,6 +293,14 @@ export class DMPApp {
     this._webViewCachePool = new DMPWebViewCachePool(this);
     this._engineStatus = new StatusMonitor();
     this._runtimeLifecycle.markReady()
+    if (afterExit) {
+      this._visibilityLedger.markRuntimeRelaunched()
+      // 重新启动的小程序带的是自己的启动场景，退出前攒下的那次返回场景已经过期。
+      this._pendingShowScene = undefined
+      this._pendingShowReferrer = undefined
+    } else {
+      this._visibilityLedger.markRuntimeReplaced()
+    }
     const deferredLaunchConfigs = this._deferredLaunchConfigs.splice(0)
     deferredLaunchConfigs.forEach((launchConfig: DMPLaunchConfig): void => {
       this.launchWhenRuntimeReady(launchConfig)
@@ -295,7 +315,7 @@ export class DMPApp {
     const appManager = DMPAppManager.sharedInstance()
     appManager.restoreExitedApp(this)
     try {
-      this.rebuildRuntime()
+      this.rebuildRuntime(true)
     } catch (error) {
       appManager.exitApp(this.appConfig.appId, this.appIndex)
       throw error as Error
@@ -454,7 +474,8 @@ export class DMPApp {
 
   private async performClose(afterPagesClosed?: () => Promise<void>) {
     this.notifyMiniProgramHide()
-    this.navigatorManager.closeAllNavigators(false)
+    // 退出对齐微信的「小程序切入后台」：只派发 App.onHide，页面不收 onUnload。
+    this.navigatorManager.closeAllNavigators(DMPPageStateTeardown.Exit, false)
     if (afterPagesClosed) {
       // The callback uses the old service runtime, so it must run after page unload is queued
       // but before destroyEngine terminates that Worker.
@@ -472,12 +493,27 @@ export class DMPApp {
 
   /** Hide only this mini program; unlike DMPAppLifecycle this never broadcasts to every pooled app. */
   public notifyMiniProgramHide() {
+    if (!this._visibilityLedger.request(false)) {
+      return
+    }
+    this.dispatchAppHide()
+  }
+
+  /**
+   * 运行时整体销毁前把终态 App.onHide 交给旧 Worker。容器留在原地，所以这不是一次容器
+   * 隐藏：销毁窗口期内到达的真实前后台变化仍记在账本上，由新运行时就绪时结算。
+   */
+  private notifyRuntimeTeardownHide() {
+    if (!this._visibilityLedger.requestRuntimeTeardownHide()) {
+      return
+    }
+    this.dispatchAppHide()
+  }
+
+  private dispatchAppHide() {
     const bridgeId = this.currentWebViewId
     if (bridgeId > 0) {
-      DMPChannelProxyNext.ContainerToService(new DMPMap({
-        type: 'pageHide',
-        body: { bridgeId }
-      }), this.appIndex)
+      this.navigatorManager.dispatchPageHide(bridgeId)
     }
     DMPChannelProxyNext.ContainerToService(new DMPMap({
       type: 'appHide',
@@ -487,6 +523,33 @@ export class DMPApp {
 
   /** Reveal only this mini program and update App.onShow/GetEnterOptionsSync data. */
   public notifyMiniProgramShow(scene: DMPScene, referrerInfo?: DMPMap) {
+    if (!this._visibilityLedger.request(true)) {
+      return
+    }
+    if (this._pendingShowScene !== undefined) {
+      const pendingScene = this._pendingShowScene
+      const pendingReferrer = this._pendingShowReferrer
+      this._pendingShowScene = undefined
+      this._pendingShowReferrer = undefined
+      this.dispatchAppShow(pendingScene, pendingReferrer)
+      return
+    }
+    this.dispatchAppShow(scene, referrerInfo)
+  }
+
+  /**
+   * 宿主在后台时把这个小程序恢复成展示中的那一个。
+   *
+   * 这不是一次可见性变化——容器整体不可见，opener 也就没有显示——所以账本不动，只记下这次
+   * 恢复该带的 scene/referrerInfo。真正的 App.onShow 由宿主回到前台时派发，届时这份
+   * enter options 会覆盖调用方的默认值，把 1038 和 referrerInfo 带到正确的那条 show 上。
+   */
+  public stashMiniProgramShow(scene: DMPScene, referrerInfo?: DMPMap) {
+    this._pendingShowScene = scene
+    this._pendingShowReferrer = referrerInfo
+  }
+
+  private dispatchAppShow(scene: DMPScene, referrerInfo?: DMPMap) {
     const record = this.navigatorManager.getActivePageRecord()
     const bridgeId = record?.webViewId ?? -1
     const body = new DMPMap({
@@ -504,10 +567,7 @@ export class DMPApp {
       body
     }), this.appIndex)
     if (bridgeId > 0) {
-      DMPChannelProxyNext.ContainerToService(new DMPMap({
-        type: 'pageShow',
-        body: { bridgeId }
-      }), this.appIndex)
+      this.navigatorManager.dispatchPageShow(bridgeId)
     }
   }
 
@@ -662,6 +722,20 @@ export class DMPApp {
     const logicJsPath = await this._bundleManager.requestLogicJsUri();
     await this._service.loadFileUri(logicJsPath);
     DMPLogger.i(Tags.LAUNCH, "startMainService end");
+  }
+
+  /**
+   * service 侧已经把 logic.js 求值完：loader.loadResource 里先 modRequire('app')（同步跑完
+   * App() → runtime.createApp() → App.onLaunch/onShow），再回报 serviceResourceLoaded。
+   * 这是唯一能保证 App 实例已存在的信号，窗口期欠下的那次 appHide 在这里补发。
+   *
+   * startMainService 返回得更早：loadFileUri 只是把 logic.js 投给 Worker，不等求值，
+   * 在那里补发会把 appHide 排在 App 实例创建之前，被 runtime.appHide() 的 this.app 判空丢掉。
+   */
+  public notifyServiceReady() {
+    if (this._visibilityLedger.markServiceReady()) {
+      this.dispatchAppHide()
+    }
   }
 
   private launchInner(launchConfig: DMPLaunchConfig) {

--- a/harmony/dimina/src/main/ets/DApp/DMPAppLifecycle.ets
+++ b/harmony/dimina/src/main/ets/DApp/DMPAppLifecycle.ets
@@ -1,10 +1,9 @@
 import window from '@ohos.window';
 import { DMPAppManager } from './DMPAppManager';
 
-import { DMPChannelProxyNext } from '../Service/DMPChannelProxyNext';
 import { DMPLogger } from '../EventTrack/DMPLogger';
 import { Tags } from '../EventTrack/Tags';
-import { DMPMap } from '../Utils/DMPMap';
+import { DMPScene } from './config/DMPLaunchConfig';
 import { DMPWebSocketManager } from '../Bridges/Network/DMPWebSocketManager';
 
 export class DMPAppLifecycle {
@@ -30,13 +29,13 @@ export class DMPAppLifecycle {
   static onAppShow() {
     const app = DMPAppManager.sharedInstance().getPresentedApp()
     if (app) {
-      const msg: DMPMap = new DMPMap({
-        type: 'appShow',
-        body: {
-          bridgeId: app.currentWebViewId
-        }
-      })
-      DMPChannelProxyNext.ContainerToService(msg, app.appIndex)
+      // Per 微信 App/Page 生命周期语义，App 从系统后台恢复前台时，当前显示页面也要收到
+      // Page.onShow（不只是 App.onShow）——这与是否跨小程序导航无关，是任何前台恢复场景
+      // 都成立的标准行为。notifyMiniProgramShow 早已实现"App+Page 双派发"（供跨小程序导航
+      // 复用），这里借用它只是为了不重复实现同一套派发逻辑；顺带保留了 app 自身的
+      // scene/path/query，不再像旧实现那样用裸 bridgeId body 覆盖 getEnterOptionsSync。
+      const launchConfig = app.getLaunchConfig()
+      app.notifyMiniProgramShow(launchConfig?.scene ?? DMPScene.fromMainEntry, launchConfig?.referrerInfo)
     }
   }
 
@@ -51,13 +50,7 @@ export class DMPAppLifecycle {
   static onAppHide() {
     const app = DMPAppManager.sharedInstance().getPresentedApp()
     if (app) {
-      const msg: DMPMap = new DMPMap({
-        type: 'appHide',
-        body: {
-          bridgeId: app.currentWebViewId
-        }
-      })
-      DMPChannelProxyNext.ContainerToService(msg, app.appIndex)
+      app.notifyMiniProgramHide()
     }
   }
 
@@ -66,6 +59,8 @@ export class DMPAppLifecycle {
     switch (stageEventType) {
       case window.WindowStageEventType.SHOWN: // 切到前台
         DMPWebSocketManager.sharedInstance().setAllBackgrounded(false)
+        // 宿主可见性要在派发之前更新：跨小程序恢复 opener 会读它决定是派发还是暂存。
+        DMPAppManager.sharedInstance().setHostVisible(true)
         DMPAppLifecycle.onShow()
         DMPLogger.i(Tags.APP_LIFECYCLE, 'windowStage foreground.');
         break;
@@ -77,6 +72,7 @@ export class DMPAppLifecycle {
         break;
       case window.WindowStageEventType.HIDDEN: // 切到后台
         DMPWebSocketManager.sharedInstance().setAllBackgrounded(true)
+        DMPAppManager.sharedInstance().setHostVisible(false)
         DMPAppLifecycle.onHide()
         DMPLogger.i(Tags.APP_LIFECYCLE, 'windowStage background.');
         break;

--- a/harmony/dimina/src/main/ets/DApp/DMPAppManager.ets
+++ b/harmony/dimina/src/main/ets/DApp/DMPAppManager.ets
@@ -33,6 +33,9 @@ export class DMPAppManager {
   private appIndex = 0;
   private miniProgramPresentations = new DMPMiniProgramPresentationStack()
   private miniProgramOperationInProgress = false
+  // 宿主自己的前后台状态，由 DMPAppLifecycle 的 windowStage 事件维护。跨小程序恢复 opener
+  // 时要看它，而不是看「谁在展示」——后者在宿主后台里同样会变。
+  private hostVisible = true
 
   public static sharedInstance(): DMPAppManager {
     if (!DMPAppManager.instance) {
@@ -225,7 +228,7 @@ export class DMPAppManager {
         await targetApp.closeDimina()
       }
       if (sourceHidden) {
-        sourceApp.notifyMiniProgramShow(sourceLaunchConfig?.scene ?? DMPScene.fromMainEntry,
+        this.resumeOpener(sourceApp, sourceLaunchConfig?.scene ?? DMPScene.fromMainEntry,
           sourceLaunchConfig?.referrerInfo)
       }
       throw error as Error
@@ -245,7 +248,7 @@ export class DMPAppManager {
         extraData
       })
       await currentApp.closeDimina(beforeClose)
-      opener.notifyMiniProgramShow(DMPScene.fromMiniProgramBack, referrerInfo)
+      this.resumeOpener(opener, DMPScene.fromMiniProgramBack, referrerInfo)
     } finally {
       this.endMiniProgramOperation()
     }
@@ -260,7 +263,7 @@ export class DMPAppManager {
       const opener = openerIndex === undefined ? undefined : this.appPools.get(openerIndex)
       await currentApp.closeDimina(beforeClose)
       if (opener) {
-        opener.notifyMiniProgramShow(DMPScene.fromMiniProgramBack, new DMPMap({
+        this.resumeOpener(opener, DMPScene.fromMiniProgramBack, new DMPMap({
           appId: currentApp.appConfig.appId
         }))
       }
@@ -314,6 +317,26 @@ export class DMPAppManager {
 
   private endMiniProgramOperation(): void {
     this.miniProgramOperationInProgress = false
+  }
+
+  /** 宿主前后台状态的唯一入口，由 DMPAppLifecycle 在 windowStage SHOWN/HIDDEN 时更新。 */
+  setHostVisible(visible: boolean): void {
+    this.hostVisible = visible
+  }
+
+  /**
+   * 把展示关系交还给 opener。
+   *
+   * 宿主在前台时这就是一次真实的 App.onShow；宿主已经进后台时（目标启动失败，或返回/退出
+   * 在后台完成）只暂存 enter options：此刻派发会让账本以为 opener 已经显示，宿主真正回到
+   * 前台时那条 show 就被去重掉，小程序再也收不到本次返回的 onShow。
+   */
+  private resumeOpener(opener: DMPApp, scene: DMPScene, referrerInfo?: DMPMap): void {
+    if (this.hostVisible) {
+      opener.notifyMiniProgramShow(scene, referrerInfo)
+    } else {
+      opener.stashMiniProgramShow(scene, referrerInfo)
+    }
   }
 
   private resolveOpener(currentApp: DMPApp, apiName: string): DMPApp {

--- a/harmony/dimina/src/main/ets/DApp/utils/DMPAppVisibilityLedger.ets
+++ b/harmony/dimina/src/main/ets/DApp/utils/DMPAppVisibilityLedger.ets
@@ -1,0 +1,82 @@
+/**
+ * App 级可见性账本。
+ *
+ * 微信里 App.onShow / App.onHide 严格交替，同一个状态不会重复派发。跨小程序打开的目标
+ * 从进入展示栈到 logic.js 跑起来之间还有一段窗口：这期间 DiminaServiceBridge 尚未注册，
+ * 直接投递的 appHide 会整条丢在 Worker 里，小程序于是在后台以为自己仍在前台。
+ *
+ * 账本只记两件事——容器认定的可见状态，和最后真正送达 service 的状态。窗口期内只更新前者，
+ * 运行时就绪时再补发差额。运行时被替换时送达状态回到「已显示」：新 Worker 自己会派发一次
+ * App.onLaunch/onShow。
+ *
+ * 容器意图与运行时寿命是两条线：换掉 Worker 不改变容器是否可见，所以 restart 期间到达的
+ * 系统前后台变化仍然记在 desired 上，由新运行时就绪时结算。只有真正「退出后重新展示」
+ * 才把意图拨回可见，见 [markRuntimeRelaunched]。
+ */
+export class DMPAppVisibilityLedger {
+  private desired: boolean = true
+  private sent: boolean = true
+  private ready: boolean = false
+
+  /**
+   * logic.js 已就绪，可以收生命周期消息了。返回 true 表示窗口期里欠了一次 appHide，
+   * 调用方现在补发——运行时未就绪时送达状态恒为「已显示」，欠账只可能是这一个方向。
+   */
+  markServiceReady(): boolean {
+    this.ready = true
+    if (this.sent === this.desired) {
+      return false
+    }
+    this.sent = this.desired
+    return true
+  }
+
+  /**
+   * 运行时即将销毁：把终态 appHide 交给旧 Worker。返回 true 表示调用方现在派发。
+   *
+   * 这不是一次容器隐藏，所以只推进送达状态、不动容器意图。派发后旧 Worker 不再是有效
+   * 投递目标（ready 归假），销毁窗口期内到达的前后台变化只记账，等新运行时结算。
+   */
+  requestRuntimeTeardownHide(): boolean {
+    if (!this.ready) {
+      return false
+    }
+    this.ready = false
+    if (!this.sent) {
+      return false
+    }
+    this.sent = false
+    return true
+  }
+
+  /** 运行时被销毁或替换：新 Worker 起来之前不能再投递，容器意图保持不变。 */
+  markRuntimeReplaced(): void {
+    this.ready = false
+    this.sent = true
+  }
+
+  /**
+   * 退出之后重新启动：容器随之重新展示，意图一并回到「已显示」。与 [markRuntimeReplaced]
+   * 的区别在于容器本身也变了——退出时记下的隐藏状态到这里已经过期。
+   */
+  markRuntimeRelaunched(): void {
+    this.markRuntimeReplaced()
+    this.desired = true
+  }
+
+  /**
+   * 请求把可见状态切到 [visible]。返回 true 表示调用方现在就该派发对应事件；
+   * 返回 false 表示状态没变，或运行时还没就绪、要等 markServiceReady 补发。
+   */
+  request(visible: boolean): boolean {
+    if (this.desired === visible) {
+      return false
+    }
+    this.desired = visible
+    if (!this.ready) {
+      return false
+    }
+    this.sent = visible
+    return true
+  }
+}

--- a/harmony/dimina/src/main/ets/DPages/DMPPageContainer.ets
+++ b/harmony/dimina/src/main/ets/DPages/DMPPageContainer.ets
@@ -234,7 +234,12 @@ export struct DMPPageContainer {
   }
 
   private closeMiniProgram() {
-    this.app.closeDimina()
+    // Route through exitMiniProgram (not closeDimina directly) so a mini program
+    // opened via navigateToMiniProgram gets its opener restored on capsule/menu
+    // close the same way wx.exitMiniProgram already does.
+    DMPAppManager.sharedInstance().exitMiniProgram(this.app, async () => {}).catch((error: Error) => {
+      DMPLogger.e(Tags.DMP_PAGE, `closeMiniProgram failed: ${error.message}`)
+    })
   }
 
   private shouldShowTabBar(): boolean {

--- a/harmony/dimina/src/main/ets/DPages/DMPPageLifecycle.ets
+++ b/harmony/dimina/src/main/ets/DPages/DMPPageLifecycle.ets
@@ -4,7 +4,16 @@ import { Tags } from '../EventTrack/Tags';
 import { DMPChannelProxyNext } from '../Service/DMPChannelProxyNext';
 import { DMPMap } from '../Utils/DMPMap';
 
-export class DMPPageLifecycle {
+// Narrow surface DMPNavigatorManager depends on, so tests can substitute a Fake
+// without constructing a real DMPApp (whose construction spins up a real
+// DMPService/Worker - unsafe to build inside a local unit test).
+export interface DMPPageLifecycleLike {
+  onShow(webviewId: number): void
+
+  onHide(webviewId: number): void
+}
+
+export class DMPPageLifecycle implements DMPPageLifecycleLike {
   app: DMPApp
 
   constructor(app: DMPApp) {

--- a/harmony/dimina/src/main/ets/Navigator/DMPNavigator.ets
+++ b/harmony/dimina/src/main/ets/Navigator/DMPNavigator.ets
@@ -12,6 +12,7 @@ import { promptAction } from '@kit.ArkUI';
 import { DMPStack } from '../Utils/DMPStack';
 import { DRouter } from './DRouter';
 import { DMPPage } from '../DPages/DMPPage';
+import { dispatchesPageUnload, DMPPageStateTeardown } from './DMPPageStateTeardown';
 
 
 export class DMPNavigator {
@@ -27,6 +28,14 @@ export class DMPNavigator {
   constructor(app: DMPApp) {
     this.app = app;
     this.pageLifecycle = new DMPPageLifecycle(app)
+  }
+
+  dispatchPageShow(webViewId: number) {
+    this.pageLifecycle.onShow(webViewId)
+  }
+
+  dispatchPageHide(webViewId: number) {
+    this.pageLifecycle.onHide(webViewId)
   }
 
   public isContainsWebViewId(webViewId: number): boolean {
@@ -230,7 +239,7 @@ export class DMPNavigator {
       DMPLogger.e(Tags.NAVIGATOR, `msg: ${(err as BusinessError).message}`)
     }
 
-    this.pageLifecycle.onShow(newWebViewId)
+    this.dispatchPageShow(newWebViewId)
   }
 
   async pop(delta: number = 1, animated: boolean = true, canDestroy = true, isReLaunch = false) {
@@ -279,17 +288,20 @@ export class DMPNavigator {
       // 用 getActivePageRecord：tab 模式下从 navigateTo 推入页面退回时，
       // 应当 onShow 真实的当前 tab，而非栈底初始 tab
       let currentPageRecord = this.app.navigatorManager.getActivePageRecord();
-      this.pageLifecycle.onShow(currentPageRecord?.webViewId ?? -1)
+      this.dispatchPageShow(currentPageRecord?.webViewId ?? -1)
 
     } catch (err) {
       DMPLogger.e(Tags.BRIDGE, `msg: ${(err as BusinessError).message}`)
     }
   }
 
-  closeAllPages(animated: boolean = false) {
+  closeAllPages(reason: DMPPageStateTeardown, animated: boolean = false) {
     const pageCount = this._stacks.size()
+    const unloadPages = dispatchesPageUnload(reason)
     for (let i = 0; i < pageCount; i++) {
-      this.pageLifecycle.onUnload(this.app.currentWebViewId)
+      if (unloadPages) {
+        this.pageLifecycle.onUnload(this.app.currentWebViewId)
+      }
       // 同 pop()：customLaunchPageCallBack 挂载的记录从未占用 NavPathStack 槽位，
       // 无条件 DRouter.pop() 会误弹宿主自己挂载的页面
       if (DMPPageRecord.shouldPopRouter(this._stacks.peek()?.ownsRouterEntry)) {
@@ -404,7 +416,7 @@ export class DMPNavigator {
     try {
       DMPLogger.i(Tags.LAUNCH, "openPage");
       DMPLogger.d(Tags.LAUNCH, "notify page.onHide start");
-      this.pageLifecycle.onHide(this.app.currentWebViewId)
+      this.dispatchPageHide(this.app.currentWebViewId)
       DMPLogger.d(Tags.LAUNCH, "notify page.onHide end");
       const pageRecord = this.preLoadPage(pagePath, params)
       // A preloaded record does not own a shared NavPathStack slot yet. Keep it false until
@@ -423,7 +435,7 @@ export class DMPNavigator {
           .start()
         pageRecord.ownsRouterEntry = DMPPageRecord.computeOwnsRouterEntry(false)
       }
-      this.pageLifecycle.onShow(pageRecord.webViewId)
+      this.dispatchPageShow(pageRecord.webViewId)
       return true
     } catch (err) {
       DMPLogger.e(Tags.NAVIGATOR, `msg: ${(err as BusinessError).message}`)
@@ -546,12 +558,12 @@ export class DMPNavigator {
 
     // Trigger onHide for previous tab (if it was actually visible)
     if (triggerPrevHide && previousWebViewId >= 0) {
-      this.pageLifecycle.onHide(previousWebViewId)
+      this.dispatchPageHide(previousWebViewId)
       DMPLogger.d(Tags.TABBAR, `onHide called for tab webViewId: ${previousWebViewId}`)
     }
 
     // Trigger onShow for current tab
-    this.pageLifecycle.onShow(currentWebViewId)
+    this.dispatchPageShow(currentWebViewId)
     DMPLogger.d(Tags.TABBAR, `onShow called for tab webViewId: ${currentWebViewId}`)
   }
 

--- a/harmony/dimina/src/main/ets/Navigator/DMPNavigatorManager.ets
+++ b/harmony/dimina/src/main/ets/Navigator/DMPNavigatorManager.ets
@@ -4,6 +4,8 @@ import { Tags } from '../EventTrack/Tags';
 import { DMPStack } from '../Utils/DMPStack';
 import { DMPNavigatorDelegate } from './DMPNavigatorDelegate';
 import { DMPPageRecord } from './DMPPageRecord';
+import { DMPPageLifecycle, DMPPageLifecycleLike } from '../DPages/DMPPageLifecycle';
+import { DMPPageStateTeardown } from './DMPPageStateTeardown';
 
 export type PopListener = (destroyRecord?: DMPPageRecord, currentRecord?: DMPPageRecord) => void;
 
@@ -22,12 +24,31 @@ export class DMPNavigatorManager {
   // 因为非首个 tab 不进入 globalPageRecordStack，仅靠栈顶无法知道用户实际在看哪个 tab，
   // 这里由 DMPTabBarContainerView 在切换时同步更新。
   private _currentTabWebViewId: number = -1
-  app: DMPApp
+  // Nullable only so tests can supply a Fake pageLifecycle without constructing a real
+  // DMPApp (whose construction spins up a real DMPService/Worker - unsafe in a local unit
+  // test). Every production call site still passes a real, non-null app; the two existing
+  // reads below were already null-safe (`?.`) before this widened from a required DMPApp.
+  app: DMPApp | null
   //页面销毁监控
   private popListeners: Set<PopListener> = new Set();
+  // pageShow/pageHide only need the app index and target webViewId - they carry no
+  // per-navigator state - so this dispatches independently of whether a navigator
+  // delegate currently sits on the stack (unlike routing through getCurNavigator(),
+  // which silently drops the page-level event whenever the stack is momentarily empty).
+  private pageLifecycle: DMPPageLifecycleLike
 
-  constructor(app: DMPApp) {
+  // pageLifecycle is injectable so tests can substitute a Fake and observe dispatch
+  // without constructing a real DMPApp. Production call sites never pass either app as
+  // null or a custom pageLifecycle - both only exist for DMPNavigatorManagerPageDispatch.test.ets.
+  constructor(app: DMPApp | null, pageLifecycle?: DMPPageLifecycleLike) {
     this.app = app;
+    if (pageLifecycle) {
+      this.pageLifecycle = pageLifecycle
+    } else if (app) {
+      this.pageLifecycle = new DMPPageLifecycle(app)
+    } else {
+      throw new Error('DMPNavigatorManager requires either a real app or an injected pageLifecycle')
+    }
   }
 
   findNavigatorByWebViewId(webViewId?: number): DMPNavigatorDelegate | undefined {
@@ -81,6 +102,14 @@ export class DMPNavigatorManager {
     return this.globalPageRecordStack.peek()
   }
 
+  dispatchPageShow(webViewId: number) {
+    this.pageLifecycle.onShow(webViewId)
+  }
+
+  dispatchPageHide(webViewId: number) {
+    this.pageLifecycle.onHide(webViewId)
+  }
+
   getPageRecordById(webViewId: number): DMPPageRecord | undefined {
     const record = this.webViewIdAndPageRecordMaps.get(webViewId);
     if (!record) {
@@ -117,10 +146,10 @@ export class DMPNavigatorManager {
     this._currentTabWebViewId = -1
   }
 
-  closeAllNavigators(animated: boolean = false) {
+  closeAllNavigators(reason: DMPPageStateTeardown, animated: boolean = false) {
     const navigators = this._navigatorDelegateStack.data.slice().reverse()
     navigators.forEach((navigatorDelegate) => {
-      navigatorDelegate.getNavigator().closeAllPages(animated)
+      navigatorDelegate.getNavigator().closeAllPages(reason, animated)
     })
     while (!this._navigatorDelegateStack.isEmpty()) {
       this.popNavigator()

--- a/harmony/dimina/src/main/ets/Navigator/DMPPageStateTeardown.ets
+++ b/harmony/dimina/src/main/ets/Navigator/DMPPageStateTeardown.ets
@@ -1,0 +1,16 @@
+/**
+ * 拆掉整个页面栈的两种原因。微信里 unloadPage 只有路由事件（reLaunch/redirectTo/
+ * navigateBack/switchTab）会触发，退出小程序走的是 onAppEnterBackground，只派发
+ * App.onHide，页面不收 onUnload。
+ */
+export enum DMPPageStateTeardown {
+  /** 路由重建页面栈：旧页面确实被路由卸载。 */
+  Routing,
+  /** 退出小程序或整体换运行时：运行时随后整体销毁，页面不派发 onUnload。 */
+  Exit,
+}
+
+/** 该原因下页面栈是否应当收到 Page.onUnload。 */
+export function dispatchesPageUnload(reason: DMPPageStateTeardown): boolean {
+  return reason === DMPPageStateTeardown.Routing
+}

--- a/harmony/dimina/src/main/ets/Service/DMPChannelProxyNext.ets
+++ b/harmony/dimina/src/main/ets/Service/DMPChannelProxyNext.ets
@@ -26,6 +26,9 @@ export class DMPChannelProxyNext {
 
     if (target === 'service') {
       if (type === 'serviceResourceLoaded') {
+        // service 侧 App 实例此刻必定已存在，补发启动窗口期欠下的 appHide。渲染层可能还没就绪
+        // （isResourceLoaded 为 false），所以放在分支之外，不跟着 resourceLoaded 一起等。
+        app.notifyServiceReady();
         app.container.hasLoadResource(webViewId, ResourceLoadType.ServiceLoaded);
         if (app.container.isResourceLoaded(webViewId)) {
           transMsg.set('type', 'resourceLoaded');

--- a/harmony/dimina/src/test/DMPAppVisibilityLedger.test.ets
+++ b/harmony/dimina/src/test/DMPAppVisibilityLedger.test.ets
@@ -1,0 +1,91 @@
+import { describe, expect, it } from '@ohos/hypium'
+import { DMPAppVisibilityLedger } from '../main/ets/DApp/utils/DMPAppVisibilityLedger'
+
+export default function dmpAppVisibilityLedgerTest() {
+  describe('DMPAppVisibilityLedger', () => {
+    it('holdsBackTheHideThatArrivesBeforeTheRuntimeIsReady', 0, () => {
+      const ledger = new DMPAppVisibilityLedger()
+
+      // 跨小程序打开的目标已经是展示栈顶，但 logic.js 还没跑起来：此刻派发就整条丢了。
+      expect(ledger.request(false)).assertFalse()
+      expect(ledger.markServiceReady()).assertTrue()
+      // 补发过一次之后不再重复。
+      expect(ledger.markServiceReady()).assertFalse()
+    })
+
+    it('dropsAWindowHideThatIsUndoneBeforeTheRuntimeIsReady', 0, () => {
+      const ledger = new DMPAppVisibilityLedger()
+
+      expect(ledger.request(false)).assertFalse()
+      expect(ledger.request(true)).assertFalse()
+      // 一进一出净变化为零，新运行时自己会派发 onLaunch/onShow，不该再补一条。
+      expect(ledger.markServiceReady()).assertFalse()
+    })
+
+    it('keepsAppShowAndAppHideStrictlyAlternating', 0, () => {
+      const ledger = new DMPAppVisibilityLedger()
+      ledger.markServiceReady()
+
+      // 启动即已显示，重复的 show 不派发。
+      expect(ledger.request(true)).assertFalse()
+      expect(ledger.request(false)).assertTrue()
+      // 退出已经派发过 hide，紧接着系统进后台不再派发第二条。
+      expect(ledger.request(false)).assertFalse()
+      expect(ledger.request(true)).assertTrue()
+    })
+
+    it('keepsTheVisibleBaselineWhenOnlyTheRuntimeIsReplaced', 0, () => {
+      const ledger = new DMPAppVisibilityLedger()
+      ledger.markServiceReady()
+
+      // restart：这条 hide 是发给旧 Worker 的终态，容器并没有隐藏。
+      expect(ledger.requestRuntimeTeardownHide()).assertTrue()
+      ledger.markRuntimeReplaced()
+
+      // 新 Worker 自带一次 onShow，账本回到「已显示且已送达」，不欠补发。
+      expect(ledger.markServiceReady()).assertFalse()
+      expect(ledger.request(true)).assertFalse()
+      expect(ledger.request(false)).assertTrue()
+    })
+
+    it('carriesASystemBackgroundAcrossARuntimeRestart', 0, () => {
+      const ledger = new DMPAppVisibilityLedger()
+      ledger.markServiceReady()
+      expect(ledger.requestRuntimeTeardownHide()).assertTrue()
+
+      // 旧 Worker 正在销毁时按下 Home：只记账，不投递给将死的运行时。
+      expect(ledger.request(false)).assertFalse()
+      ledger.markRuntimeReplaced()
+
+      // 新运行时就绪时补上真实的后台状态，而不是以为自己在前台。
+      expect(ledger.markServiceReady()).assertTrue()
+      expect(ledger.request(true)).assertTrue()
+    })
+
+    it('doesNotRepeatTheHideWhenTheRuntimeIsReplacedWhileHidden', 0, () => {
+      const ledger = new DMPAppVisibilityLedger()
+      ledger.markServiceReady()
+      expect(ledger.request(false)).assertTrue()
+
+      // 已经隐藏过，销毁时不再重复一条 appHide。
+      expect(ledger.requestRuntimeTeardownHide()).assertFalse()
+      ledger.markRuntimeReplaced()
+
+      // 容器仍在后台，新运行时必须知道。
+      expect(ledger.markServiceReady()).assertTrue()
+    })
+
+    it('restoresTheVisibleBaselineWhenTheAppRelaunchesAfterExit', 0, () => {
+      const ledger = new DMPAppVisibilityLedger()
+      ledger.markServiceReady()
+      // 退出：容器真的隐藏了。
+      expect(ledger.request(false)).assertTrue()
+
+      ledger.markRuntimeRelaunched()
+
+      // 重新展示，新 Worker 自带 onShow，不该再补一条 appHide。
+      expect(ledger.markServiceReady()).assertFalse()
+      expect(ledger.request(false)).assertTrue()
+    })
+  })
+}

--- a/harmony/dimina/src/test/DMPNavigatorManagerPageDispatch.test.ets
+++ b/harmony/dimina/src/test/DMPNavigatorManagerPageDispatch.test.ets
@@ -1,0 +1,37 @@
+import { describe, expect, it } from '@ohos/hypium'
+import { DMPNavigatorManager } from '../main/ets/Navigator/DMPNavigatorManager'
+import { DMPPageLifecycleLike } from '../main/ets/DPages/DMPPageLifecycle'
+
+class FakePageLifecycle implements DMPPageLifecycleLike {
+  shownWebViewIds: number[] = []
+  hiddenWebViewIds: number[] = []
+
+  onShow(webviewId: number): void {
+    this.shownWebViewIds.push(webviewId)
+  }
+
+  onHide(webviewId: number): void {
+    this.hiddenWebViewIds.push(webviewId)
+  }
+}
+
+export default function dmpNavigatorManagerPageDispatchTest() {
+  describe('DMPNavigatorManagerPageDispatch', () => {
+    it('dispatchesPageShowAndHideEvenWhenTheNavigatorStackIsEmpty', 0, () => {
+      // dispatchPageShow/dispatchPageHide never read `app` - only pageLifecycle does,
+      // and it's replaced with the Fake below - so a real DMPApp (which would spin up
+      // a DMPService/Worker on construction) is never needed here. `app` accepts null
+      // specifically for this case (see DMPNavigatorManager's constructor).
+      const fakePageLifecycle = new FakePageLifecycle()
+      const manager = new DMPNavigatorManager(null, fakePageLifecycle)
+
+      expect(manager.isEmpty()).assertTrue()
+
+      manager.dispatchPageShow(42)
+      manager.dispatchPageHide(42)
+
+      expect(fakePageLifecycle.shownWebViewIds).assertDeepEquals([42])
+      expect(fakePageLifecycle.hiddenWebViewIds).assertDeepEquals([42])
+    })
+  })
+}

--- a/harmony/dimina/src/test/DMPPageStateTeardown.test.ets
+++ b/harmony/dimina/src/test/DMPPageStateTeardown.test.ets
@@ -1,0 +1,18 @@
+import { describe, expect, it } from '@ohos/hypium'
+import { dispatchesPageUnload, DMPPageStateTeardown } from '../main/ets/Navigator/DMPPageStateTeardown'
+
+export default function dmpPageStateTeardownTest() {
+  describe('DMPPageStateTeardown', () => {
+    it('routingTeardownUnloadsThePages', 0, () => {
+      // 微信的 unloadPage 只由路由事件驱动（reLaunch/redirectTo/navigateBack/switchTab），
+      // 这些页面确实被路由销毁，JS 侧必须收到 onUnload。
+      expect(dispatchesPageUnload(DMPPageStateTeardown.Routing)).assertTrue()
+    })
+
+    it('exitTeardownDoesNotUnloadThePages', 0, () => {
+      // 退出小程序走的是 onAppEnterBackground：只派发 App.onHide，页面不收 onUnload，
+      // 运行时紧接着整体销毁。iOS 的 PageStateTeardown.exit 与这里同源。
+      expect(dispatchesPageUnload(DMPPageStateTeardown.Exit)).assertFalse()
+    })
+  })
+}

--- a/harmony/dimina/src/test/List.test.ets
+++ b/harmony/dimina/src/test/List.test.ets
@@ -14,6 +14,9 @@ import dmpMiniProgramNavigationCallbackTest from './DMPMiniProgramNavigationCall
 import dmpAppRuntimeLifecycleTest from './DMPAppRuntimeLifecycle.test';
 import dmpContainerCallbackContractTest from './DMPContainerCallbackContract.test';
 import dmpWebResourceImageFormatTest from './DMPWebResourceImageFormat.test';
+import dmpNavigatorManagerPageDispatchTest from './DMPNavigatorManagerPageDispatch.test';
+import dmpAppVisibilityLedgerTest from './DMPAppVisibilityLedger.test';
+import dmpPageStateTeardownTest from './DMPPageStateTeardown.test';
 import dmpFileUrlConvertorTest from './DMPFileUrlConvertor.test';
 import dmpCanvasCallbackTest from './DMPCanvasCallback.test';
 import dmpCanvasExportJobRegistryTest from './DMPCanvasExportJobRegistry.test';
@@ -36,6 +39,9 @@ export default function testsuite() {
   dmpAppRuntimeLifecycleTest();
   dmpContainerCallbackContractTest();
   dmpWebResourceImageFormatTest();
+  dmpNavigatorManagerPageDispatchTest();
+  dmpAppVisibilityLedgerTest();
+  dmpPageStateTeardownTest();
   dmpFileUrlConvertorTest();
   dmpCanvasCallbackTest();
   dmpCanvasExportJobRegistryTest();

--- a/iOS/dimina/DiminaKit/App/DMPApp.swift
+++ b/iOS/dimina/DiminaKit/App/DMPApp.swift
@@ -18,12 +18,37 @@ public class DMPApp {
     private var currentLaunchConfig: DMPLaunchConfig?
     
     public var render: DMPRender?
-    public var service: DMPService?
+    public var service: DMPService? {
+        didSet {
+            guard service !== oldValue else { return }
+            // 新 service 是新的 JS 运行时：bundle 还没求值，它自己随后会派发一次
+            // App.onLaunch/onShow，所以送达状态回到「已显示」，等就绪再补差额。
+            // 容器意图不动——换掉运行时不等于容器隐藏，重启期间到达的真实前后台变化
+            // 记在 appVisibleDesired 上，由新运行时就绪时结算。
+            appRuntimeReady = false
+            appVisibleSent = true
+        }
+    }
     public var container: DMPContainer?
     public var containerApi: DMPContainerApi?
 
     private var isLaunching = false
     private var isDestroyed = false
+
+    // App 级可见性账本。微信里 App.onShow/onHide 严格交替，同一个状态不会重复派发；
+    // 而跨小程序打开的目标在启动窗口里还没有 service，此刻到达的系统前后台事件直接
+    // 发出去就整条丢了，小程序会在后台以为自己仍在前台。账本只记两件事：容器认定的
+    // 可见状态，和最后真正送达 service 的状态，两者不一致且 service 存在时才派发。
+    // 起点是「已显示」：小程序启动本身就是一次 onShow，由 JS 侧自己派发。
+    private var appVisibleDesired = true
+    private var appVisibleSent = true
+    // service.js / logic.js 求值之前 DiminaServiceBridge 还不存在，此刻投递的消息
+    // 会在引擎队列里整条丢掉，所以就绪之前只记账不派发。
+    private var appRuntimeReady = false
+    // 宿主在后台时被交还展示关系的小程序：容器意图仍是不可见，这次恢复该带的 enter options
+    // 先存在这里，等宿主真正回到前台、账本第一次派发 App.onShow 时一并交出去。
+    private var pendingShowScene: Int?
+    private var pendingShowReferrerInfo: [String: Any]?
     
     public init(appConfig: DMPAppConfig, appIndex: Int) {
         self.appConfig = appConfig
@@ -73,8 +98,7 @@ public class DMPApp {
             return false
         }
 
-        await openPage(launchConfig: launchConfig)
-        return true
+        return await openPage(launchConfig: launchConfig)
     }
 
     @MainActor
@@ -232,6 +256,17 @@ public class DMPApp {
         await service?.loadFile(path: DMPSandboxManager.appServicePath(appId: appId))
     }
 
+    /// service 侧 App 实例已经存在，可以接生命周期消息了：把启动窗口期只记在账本里、
+    /// 还没派发的可见性变化补上。
+    ///
+    /// 只有 `serviceResourceLoaded` 能给出这个保证。`loadFile` 返回时 logic.js 才刚被投给
+    /// 引擎求值，App 实例要等 loader 的 `modRequire('app')` 才建出来；在那之前投递的 appHide
+    /// 会被 service 侧 `runtime.appHide()` 的 `this.app` 判空静默丢掉。
+    func markAppRuntimeReady() {
+        appRuntimeReady = true
+        flushAppVisibility()
+    }
+
     func notifyUpdateStatus(event: String) async {
         let message = DMPMap([
             "type": "onUpdateStatusChange",
@@ -243,7 +278,8 @@ public class DMPApp {
     }
 
     @MainActor
-    public func openPage(launchConfig: DMPLaunchConfig) async {
+    @discardableResult
+    public func openPage(launchConfig: DMPLaunchConfig) async -> Bool {
         DMPLogger.debug("openPage")
         var newLaunchConfig = launchConfig
         // 尊重调用方指定的启动页（扫码/分享等场景从内页启动，此时导航栏按
@@ -252,7 +288,8 @@ public class DMPApp {
         // DMPBundleAppConfig.entryPagePath 及页面栈 key 同口径
         newLaunchConfig.appEntryPath = resolvedEntryPath(for: launchConfig)
         currentLaunchConfig = newLaunchConfig
-        await navigator?.launch(to: newLaunchConfig.appEntryPath ?? "", query: newLaunchConfig.query)
+        guard let navigator else { return false }
+        return await navigator.launch(to: newLaunchConfig.appEntryPath ?? "", query: newLaunchConfig.query)
     }
 
     private func resolvedEntryPath(for launchConfig: DMPLaunchConfig) -> String {
@@ -434,6 +471,106 @@ public class DMPApp {
             msg: DMPMap(["type": "appShow", "body": body]),
             app: self
         )
+    }
+
+    @MainActor
+    func notifyMiniProgramHide() {
+        notifyMiniProgramHide(webViewId: getCurrentWebViewId())
+    }
+
+    @MainActor
+    func notifyMiniProgramHide(webViewId: Int) {
+        guard appVisibleDesired else { return }
+        appVisibleDesired = false
+        guard appRuntimeReady else { return }
+        appVisibleSent = false
+        if webViewId > 0 {
+            navigator?.dispatchPageHide(webViewId: webViewId)
+        }
+        notifyAppHide()
+    }
+
+    /// 运行时整体销毁前把终态 App.onHide 交给旧 service。
+    ///
+    /// 这不是一次容器隐藏，所以只推进送达状态、不动 `appVisibleDesired`：重启期间到达的
+    /// 系统前后台变化才是容器的真实意图，要留给新运行时结算。派发后旧 service 不再是有效
+    /// 投递目标，`appRuntimeReady` 一并归假，避免这段窗口里的事件发给正在销毁的引擎。
+    @MainActor
+    func notifyRuntimeTeardownHide() {
+        guard appRuntimeReady else { return }
+        appRuntimeReady = false
+        guard appVisibleSent else { return }
+        appVisibleSent = false
+        let webViewId = getCurrentWebViewId()
+        if webViewId > 0 {
+            navigator?.dispatchPageHide(webViewId: webViewId)
+        }
+        notifyAppHide()
+    }
+
+    @MainActor
+    func notifyMiniProgramShow(scene: Int? = nil, referrerInfo: [String: Any]? = nil) {
+        notifyMiniProgramShow(
+            webViewId: getCurrentWebViewId(),
+            scene: scene,
+            referrerInfo: referrerInfo
+        )
+    }
+
+    @MainActor
+    func notifyMiniProgramShow(
+        webViewId: Int,
+        scene: Int? = nil,
+        referrerInfo: [String: Any]? = nil
+    ) {
+        guard !appVisibleDesired else { return }
+        appVisibleDesired = true
+        guard appRuntimeReady else { return }
+        appVisibleSent = true
+        let options = consumePendingShow(scene: scene, referrerInfo: referrerInfo)
+        notifyAppShow(scene: options.scene, referrerInfo: options.referrerInfo)
+        guard webViewId > 0 else { return }
+        navigator?.dispatchPageShow(webViewId: webViewId)
+    }
+
+    /// 宿主在后台时把这个小程序恢复成展示中的那一个。
+    ///
+    /// 这不是一次可见性变化——容器整体不可见，opener 也就没有显示——所以账本不动，只记下
+    /// 这次恢复该带的 scene/referrerInfo。真正的 App.onShow 由宿主回到前台时派发，届时
+    /// 这份 enter options 会覆盖掉调用方的默认值，把 1038 和 referrerInfo 带到正确的那条
+    /// show 上。
+    @MainActor
+    func stashMiniProgramShow(scene: Int?, referrerInfo: [String: Any]?) {
+        pendingShowScene = scene
+        pendingShowReferrerInfo = referrerInfo
+    }
+
+    /// 取出并清空暂存的 enter options；没有暂存时原样返回调用方传入的值。
+    private func consumePendingShow(
+        scene: Int?,
+        referrerInfo: [String: Any]?
+    ) -> (scene: Int?, referrerInfo: [String: Any]?) {
+        guard pendingShowScene != nil || pendingShowReferrerInfo != nil else {
+            return (scene, referrerInfo)
+        }
+        let pending = (scene: pendingShowScene, referrerInfo: pendingShowReferrerInfo)
+        pendingShowScene = nil
+        pendingShowReferrerInfo = nil
+        return pending
+    }
+
+    /// 结算账本：service 缺席期间记下的可见性变化，在新 service 出现时补发。
+    /// 只补 App 级事件——页面级的 show/hide 由当时的页面栈决定，缺席期间那些
+    /// 页面并不存在，补发一条针对旧 webViewId 的消息只会送到已经没了的页面。
+    private func flushAppVisibility() {
+        guard appRuntimeReady, appVisibleSent != appVisibleDesired else { return }
+        appVisibleSent = appVisibleDesired
+        if appVisibleDesired {
+            let options = consumePendingShow(scene: nil, referrerInfo: nil)
+            notifyAppShow(scene: options.scene, referrerInfo: options.referrerInfo)
+        } else {
+            notifyAppHide()
+        }
     }
 
     /// 注册第三方扩展 bridge 模块。

--- a/iOS/dimina/DiminaKit/App/DMPAppManager.swift
+++ b/iOS/dimina/DiminaKit/App/DMPAppManager.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 
 enum DMPMiniProgramNavigationError: LocalizedError {
     case invalidAppId
@@ -70,8 +71,19 @@ public class DMPAppManager {
     /// operation suspends across await points, so reject overlapping
     /// navigate/back/exit/restart transactions explicitly.
     @MainActor private var isMiniProgramOperationInProgress = false
+    /// 宿主自己的前后台状态，由 [setupSystemLifecycleObservers] 维护。跨小程序恢复 opener
+    /// 时要看它，而不是看「谁在展示」——后者在宿主后台里同样会变。
+    @MainActor private var hostVisible = true
 
-    private init() {}
+    private var systemLifecycleObservers: [NSObjectProtocol] = []
+
+    private init() {
+        setupSystemLifecycleObservers()
+    }
+
+    deinit {
+        systemLifecycleObservers.forEach(NotificationCenter.default.removeObserver)
+    }
 
     public static func sharedInstance() -> DMPAppManager {
         return instance
@@ -86,7 +98,53 @@ public class DMPAppManager {
         defer { stateLock.unlock() }
         return body()
     }
-    
+
+    /// UIApplication has exactly one foreground scene worth caring about here (no split-screen /
+    /// Stage Manager support in this container), so the *whole* pool's system background verdict
+    /// funnels through the one mini program actually on screen - the DMPApp whose navigator
+    /// currently owns the shared UINavigationController. Suspended openers behind it are, by
+    /// definition, already hidden (see [DMPNavigator.notifyPresentOut]) and receive nothing here.
+    ///
+    /// 这两个通知也是宿主可见性的唯一来源。跨小程序返回可以发生在宿主已经进后台之后
+    /// （目标启动失败、或返回操作在后台完成），那时把 opener 恢复成展示中的小程序并不等于
+    /// 它可见，所以 [hostVisible] 要独立于「谁在展示」记住宿主自己的前后台状态。
+    private func setupSystemLifecycleObservers() {
+        let center = NotificationCenter.default
+        systemLifecycleObservers = [
+            center.addObserver(
+                forName: UIApplication.didEnterBackgroundNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in
+                    self?.hostVisible = false
+                    self?.activePresentedApp()?.notifyMiniProgramHide()
+                }
+            },
+            center.addObserver(
+                forName: UIApplication.willEnterForegroundNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in
+                    self?.hostVisible = true
+                    self?.activePresentedApp()?.notifyMiniProgramShow()
+                }
+            },
+        ]
+    }
+
+    /// The one DMPApp whose navigator currently owns the shared UINavigationController - the
+    /// mini program actually on screen. `nil` when nothing is presented (e.g. an empty pool, or
+    /// mid owner hand-off).
+    @MainActor
+    private func activePresentedApp() -> DMPApp? {
+        stateLock.lock()
+        let apps = Array(appPools.values)
+        stateLock.unlock()
+        return apps.first { $0.getNavigator()?.isActiveNavigationOwner() == true }
+    }
+
     func getApp(appIndex: Int) -> DMPApp? {
         return withStateLock { appPools[appIndex] }
     }
@@ -207,6 +265,20 @@ public class DMPAppManager {
         }
     }
 
+    /// Establishes the same opener/target relationship `navigateToMiniProgram`
+    /// records after a successful launch, without requiring a real bundled
+    /// launch. Exists so tests can exercise `navigateBackMiniProgram` /
+    /// `exitMiniProgram`'s opener-restoration paths directly.
+    func markOpenedByMiniProgramForTesting(target: DMPApp, opener: DMPApp) {
+        setOpenerContext(
+            MiniProgramOpenerContext(
+                openerAppIndex: opener.getAppIndex(),
+                targetAppId: target.getAppId()
+            ),
+            for: target.getAppIndex()
+        )
+    }
+
     // MARK: - Mini Program Navigation
 
     @MainActor
@@ -226,6 +298,13 @@ public class DMPAppManager {
     @MainActor
     func isMiniProgramOperationInFlight() -> Bool {
         return isMiniProgramOperationInProgress
+    }
+
+    /// 宿主前后台状态的只读视图。系统通知是异步送达的，测试用它确认通知已经生效，
+    /// 再驱动依赖这个真相的跨小程序恢复路径。
+    @MainActor
+    func isHostVisibleForTesting() -> Bool {
+        return hostVisible
     }
 
     @MainActor
@@ -297,9 +376,8 @@ public class DMPAppManager {
             )
             guard launched else {
                 target.destroy()
-                opener.notifyAppShow()
                 openerNavigator.reactivate()
-                openerNavigator.resumeAfterMiniProgramNavigation()
+                openerNavigator.resumeAfterMiniProgramNavigation(hostVisible: hostVisible)
                 throw DMPMiniProgramNavigationError.targetLaunchFailed(appId)
             }
 
@@ -439,28 +517,18 @@ public class DMPAppManager {
         _ context: MiniProgramOpenerContext,
         extraData: [String: Any]?
     ) {
-        guard let opener = notifyOpenerReturn(context, extraData: extraData),
+        guard let opener = getApp(appIndex: context.openerAppIndex),
               let openerNavigator = opener.getNavigator() else { return }
-        openerNavigator.reactivate()
-        openerNavigator.resumeAfterMiniProgramNavigation()
-    }
-
-    @MainActor
-    @discardableResult
-    private func notifyOpenerReturn(
-        _ context: MiniProgramOpenerContext,
-        extraData: [String: Any]?
-    ) -> DMPApp? {
-        guard let opener = getApp(appIndex: context.openerAppIndex) else { return nil }
         var referrerInfo: [String: Any] = ["appId": context.targetAppId]
         if let extraData {
             referrerInfo["extraData"] = extraData
         }
-        opener.notifyAppShow(
+        openerNavigator.reactivate()
+        openerNavigator.resumeAfterMiniProgramNavigation(
             scene: DMPScene.fromMiniProgramBack.rawValue,
-            referrerInfo: referrerInfo
+            referrerInfo: referrerInfo,
+            hostVisible: hostVisible
         )
-        return opener
     }
 
     // MARK: - Ext Module Registration

--- a/iOS/dimina/DiminaKit/Container/DMPChannelProxy.swift
+++ b/iOS/dimina/DiminaKit/Container/DMPChannelProxy.swift
@@ -28,6 +28,11 @@ class DMPChannelProxy {
             ])
 
             if type == "serviceResourceLoaded" || type == "renderResourceLoaded" {
+                if type == "serviceResourceLoaded" {
+                    // service 端发出这条消息时 loader 已经跑完 modRequire('app')，App 实例必定存在。
+                    // 渲染层是否就绪与此无关，所以放在 isResourceLoaded 分支之外。
+                    app.markAppRuntimeReady()
+                }
                 guard let container = app.container else {
                     DMPLogger.debug("resourceLoaded ignored: runtime container is unavailable")
                     return DMPMap()

--- a/iOS/dimina/DiminaKit/Container/DMPPageController.swift
+++ b/iOS/dimina/DiminaKit/Container/DMPPageController.swift
@@ -25,6 +25,10 @@ public class DMPPageController: UIViewController {
     private let isRoot: Bool
     private let showsLaunchLoading: Bool
 
+    // 这个页面为什么被拆掉。默认按路由处理：系统主动回收、宿主自己 pop 都属于路由，
+    // 页面照常卸载。退出小程序由关闭方在拆栈之前标注，见 DMPNavigator.markPageTeardownReason。
+    private var pageStateTeardownReason: DMPPageStateTeardown = .routing
+
     // WebView related
     private var webview: DMPWebview
     private let loadingStateObserverToken = UUID()
@@ -974,9 +978,9 @@ public class DMPPageController: UIViewController {
         DMPLogger.debug("🗑️ DMPPageController: Destroy WebView (ID: \(webview.getWebViewId()))")
         isWebViewDestroyed = true
         webview.clearLoadingStateObserver(ownerToken: loadingStateObserverToken)
-        
+
         // Notify page unload
-        if let app = app {
+        if pageStateTeardownReason == .routing, let app = app {
             let msg = DMPMap([
                 "type": "pageUnload",
                 "body": [
@@ -990,6 +994,12 @@ public class DMPPageController: UIViewController {
         app?.render?.releaseWebView(webview)
     }
     
+    /// 标注这次拆栈的原因。必须在页面离开导航栈之前调用：销毁可能要等转场动画结束才发生，
+    /// 那时导航栈里已经找不到这个控制器了。
+    public func markTeardownReason(_ reason: DMPPageStateTeardown) {
+        pageStateTeardownReason = reason
+    }
+
     // Manual destroy method (for external calls)
     public func destroy() {
         destroyWebView()

--- a/iOS/dimina/DiminaKit/Container/DMPPageLifecycle.swift
+++ b/iOS/dimina/DiminaKit/Container/DMPPageLifecycle.swift
@@ -5,6 +5,16 @@
 //  Created by Lehem on 2025/4/27.
 //
 
+/// 拆掉页面的两种原因。微信里 unloadPage 只有路由事件（reLaunch/redirectTo/
+/// navigateBack/switchTab）会触发，退出小程序走的是 onAppEnterBackground，
+/// 只派发 App.onHide，页面不收 onUnload。
+public enum DMPPageStateTeardown {
+    /// 路由卸载页面：页面确实被路由销毁。
+    case routing
+    /// 退出小程序或整体换运行时：运行时随后整体销毁，页面不派发 onUnload。
+    case exit
+}
+
 public class DMPPageLifecycle {
     var app: DMPApp
     

--- a/iOS/dimina/DiminaKit/Container/DMPTabBarContainerController.swift
+++ b/iOS/dimina/DiminaKit/Container/DMPTabBarContainerController.swift
@@ -23,6 +23,9 @@ final class DMPTabBarContainerController: UIViewController {
     )
     private var tabBarHeightConstraint: NSLayoutConstraint?
     private var tabControllers: [Int: DMPPageController] = [:]
+    // tab 页的销毁和普通页一样可能晚到转场之后，原因由容器统一持有并转交给每个 tab 页，
+    // 包括标注之后才建出来的那个。
+    private var pageStateTeardownReason: DMPPageStateTeardown = .routing
     private var tabPageRecords: [Int: DMPPageRecord] = [:]
 
     private(set) var selectedIndex: Int = 0
@@ -199,6 +202,11 @@ final class DMPTabBarContainerController: UIViewController {
         tabBarView.hideRedDot(index: index)
     }
 
+    func markTeardownReason(_ reason: DMPPageStateTeardown) {
+        pageStateTeardownReason = reason
+        tabControllers.values.forEach { $0.markTeardownReason(reason) }
+    }
+
     func destroy() {
         tabControllers.values.forEach { $0.destroy() }
     }
@@ -259,6 +267,7 @@ final class DMPTabBarContainerController: UIViewController {
         pageRecord.query = query
         pageRecord.navStyle = app.getBundleAppConfig()?.getPageConfig(pagePath: pagePath)
 
+        pageController.markTeardownReason(pageStateTeardownReason)
         tabControllers[index] = pageController
         tabPageRecords[index] = pageRecord
         attachLoadedTabIfNeeded(index)

--- a/iOS/dimina/DiminaKit/Navigator/DMPNavigator.swift
+++ b/iOS/dimina/DiminaKit/Navigator/DMPNavigator.swift
@@ -297,31 +297,66 @@ public class DMPNavigator: NSObject {
         notifyPresentOut()
     }
 
-    /// Deliver the app/page presentation-out lifecycle while the old service
-    /// is still alive. Callers decide the API callback commit point, then this
-    /// method keeps App.onHide ahead of the current Page.onHide like the shared
-    /// runtime's MiniApp.onPresentOut().
     @MainActor
-    private func notifyPresentOut() {
-        guard isActiveNavigationOwner() else { return }
-        app?.notifyAppHide()
-        if let record = pageRecords.last {
-            pageLifecycle?.onHide(webviewId: record.webViewId)
-        }
+    func dispatchPageShow(webViewId: Int) {
+        pageLifecycle?.onShow(webviewId: webViewId)
     }
 
     @MainActor
-    func resumeAfterMiniProgramNavigation() {
+    func dispatchPageHide(webViewId: Int) {
+        pageLifecycle?.onHide(webviewId: webViewId)
+    }
+
+    @MainActor
+    private func notifyPresentOut() {
         guard isActiveNavigationOwner() else { return }
-        if let record = pageRecords.last {
-            pageLifecycle?.onShow(webviewId: record.webViewId)
+        app?.notifyMiniProgramHide()
+    }
+
+    /// restart 专用：容器留在原地，被换掉的是运行时，所以这条 App.onHide 是发给旧 service
+    /// 的终态，而不是一次容器隐藏。
+    @MainActor
+    private func notifyRuntimeTeardownOut() {
+        guard isActiveNavigationOwner() else { return }
+        app?.notifyRuntimeTeardownHide()
+    }
+
+    /// - Parameter hostVisible: 宿主此刻是否真的在前台。为 false 时这次恢复只交还展示关系，
+    ///   不派发 App.onShow：容器整体不可见，此刻派发会让账本以为已经显示，宿主真正回到
+    ///   前台时那条 show 就被去重掉，小程序再也收不到本次返回的 onShow。
+    @MainActor
+    func resumeAfterMiniProgramNavigation(
+        scene: Int? = nil,
+        referrerInfo: [String: Any]? = nil,
+        hostVisible: Bool
+    ) {
+        guard isActiveNavigationOwner() else { return }
+        if hostVisible {
+            app?.notifyMiniProgramShow(scene: scene, referrerInfo: referrerInfo)
+        } else {
+            app?.stashMiniProgramShow(scene: scene, referrerInfo: referrerInfo)
         }
         setCapsuleVisible(true)
         bringCapsuleToFront()
     }
 
-    private func clearMiniProgramPageState() {
-        pageRecords.reversed().forEach { pageLifecycle?.onUnload(webviewId: $0.webViewId) }
+    /// 把拆栈原因交给页面控制器本身。真正发 pageUnload 的是 DMPPageController 的销毁路径，
+    /// 而它可能晚到转场动画结束后的 viewDidDisappear、甚至 deinit——那时导航栈里已经没有
+    /// 这些控制器了，只能在离栈之前标注。
+    private func markPageTeardownReason(_ reason: DMPPageStateTeardown) {
+        tabBarContainerController?.markTeardownReason(reason)
+        guard let navigationController else { return }
+        for controller in ownedViewControllers(in: navigationController) {
+            (controller as? DMPPageController)?.markTeardownReason(reason)
+            (controller as? DMPTabBarContainerController)?.markTeardownReason(reason)
+        }
+    }
+
+    private func clearMiniProgramPageState(reason: DMPPageStateTeardown) {
+        markPageTeardownReason(reason)
+        if reason == .routing {
+            pageRecords.reversed().forEach { pageLifecycle?.onUnload(webviewId: $0.webViewId) }
+        }
         tabBarContainerController?.destroy()
         tabBarContainerController = nil
         pageRecords.removeAll()
@@ -368,23 +403,28 @@ public class DMPNavigator: NSObject {
 
     /// 启动到指定页面
     @MainActor
+    /// - Returns: whether a page actually ended up pushed onto the navigation stack. Callers that
+    ///   roll a failed cross-mini-program launch back into the foreground (see
+    ///   `DMPAppManager.navigateToMiniProgram`) depend on this being accurate - `true` on a launch
+    ///   that left the screen blank previously stranded the opener with no way back.
+    @discardableResult
     public func launch(
         to path: String, query: [String: Any]? = nil, animated: Bool = true,
         showsLaunchLoading: Bool = true
-    ) async {
+    ) async -> Bool {
         guard let navigationController = navigationController else {
             DMPLogger.debug("导航控制器未设置")
-            return
+            return false
         }
         guard isActiveNavigationOwner() else {
             DMPLogger.debug("launch skipped: navigator is not the active owner")
-            return
+            return false
         }
         pageRouteOperationDepth += 1
         defer { pageRouteOperationDepth -= 1 }
 
         navigationController.view.endEditing(true)
-        pageLifecycle?.onHide(webviewId: app!.getCurrentWebViewId())
+        dispatchPageHide(webViewId: app!.getCurrentWebViewId())
 
         if let tabBarConfig = app?.getBundleAppConfig()?.tabBar,
            isTabBarPage(path)
@@ -400,9 +440,9 @@ public class DMPNavigator: NSObject {
             )
 
             guard let pageRecord = await tabBarController.prepareInitialTab() else {
-                return
+                return false
             }
-            guard isActiveNavigationOwner() else { return }
+            guard isActiveNavigationOwner() else { return false }
 
             pageRecords.append(pageRecord)
             tabBarContainerController = tabBarController
@@ -412,8 +452,8 @@ public class DMPNavigator: NSObject {
             }
             navigationController.pushViewController(tabBarController, animated: animated)
 
-            pageLifecycle?.onShow(webviewId: pageRecord.webViewId)
-            return
+            dispatchPageShow(webViewId: pageRecord.webViewId)
+            return true
         }
 
         // 使用DMPPageController创建页面
@@ -435,14 +475,15 @@ public class DMPNavigator: NSObject {
         pageRecords.append(pageRecord)
 
         await app?.service?.loadSubPackage(pagePath: path)
-        guard isActiveNavigationOwner() else { return }
+        guard isActiveNavigationOwner() else { return false }
 
         if showsLaunchLoading {
             pageController.preparePageLoading(in: navigationController)
         }
         navigationController.pushViewController(pageController, animated: animated)
 
-        pageLifecycle?.onShow(webviewId: pageController.getWebView().getWebViewId())
+        dispatchPageShow(webViewId: pageController.getWebView().getWebViewId())
+        return true
     }
 
     /// 导航到指定页面
@@ -467,7 +508,7 @@ public class DMPNavigator: NSObject {
             return
         }
 
-        pageLifecycle?.onHide(webviewId: app!.getCurrentWebViewId())
+        dispatchPageHide(webViewId: app!.getCurrentWebViewId())
 
         // 使用DMPPageController创建页面
         let pageController = DMPPageController(
@@ -498,7 +539,7 @@ public class DMPNavigator: NSObject {
 
         navigationController.pushViewController(pageController, animated: animated)
 
-        pageLifecycle?.onShow(webviewId: pageController.getWebView().getWebViewId())
+        dispatchPageShow(webViewId: pageController.getWebView().getWebViewId())
     }
 
     /// 返回上一页或多页
@@ -514,37 +555,46 @@ public class DMPNavigator: NSObject {
         }
 
         navigationController.view.endEditing(true)
-        // 检查是否可以返回
-        if navigationController.viewControllers.count <= 1 {
-            if destroy {
+
+        // 退出判定对两种宿主拓扑同源：hostViewControllers 在跨小程序场景返回启动前保留的宿主栈，
+        // 独占导航栈时按「栈底连续的非小程序控制器」推断。currentIndex 不高于宿主段，说明小程序
+        // 自己只剩一个页面、没有可回退的页面，这次返回就是一次退出而不是路由。
+        let hostControllers = hostViewControllers(in: navigationController)
+        let currentIndex = navigationController.viewControllers.count - 1
+        if currentIndex <= hostControllers.count {
+            // 被另一个小程序拉起的 guest 只能从 exitMiniProgram / navigateBackMiniProgram 通道
+            // 退出——那里才会把 scene 1038 和 referrerInfo 交还 opener、并回收 target 运行时。
+            // 首页上的返回在微信同样是失败而非退出，所以这里不派发任何生命周期。
+            guard miniProgramBaseViewControllers == nil else {
+                DMPLogger.debug("navigateBack skipped: guest mini program has no page to pop")
+                return
+            }
+            guard destroy else { return }
+            setCapsuleVisible(false)
+            // 退出对齐微信的「小程序切入后台」：栈顶页先 onHide，App 再 onHide。关闭不派发
+            // onUnload——微信的 unloadPage 只由路由事件驱动，退出走的是 onAppEnterBackground。
+            let hidingWebViewId = app?.getCurrentWebViewId() ?? -1
+            // 标注必须早于 pop：动画结束后才走 viewDidDisappear，那时这些控制器已经离栈，
+            // clearMiniProgramPageState 再标注就来不及了。
+            markPageTeardownReason(.exit)
+            if let hostTopController = hostControllers.last {
+                navigationController.popToViewController(hostTopController, animated: animated)
+            }
+            app?.notifyMiniProgramHide(webViewId: hidingWebViewId)
+            clearMiniProgramPageState(reason: .exit)
+            if hostControllers.isEmpty {
+                // 没有宿主控制器可退回，页面壳随小程序一起消失，运行时也没有保活的意义。
                 app?.destroy()
             }
             return
         }
 
         // 计算要返回的目标控制器索引
-        let currentIndex = navigationController.viewControllers.count - 1
-        let targetFloor = miniProgramBaseViewControllers?.count ?? 0
-        let targetIndex = max(currentIndex - max(delta, 1), targetFloor)
+        let targetIndex = max(currentIndex - max(delta, 1), hostControllers.count)
 
-        // 如果目标是根控制器，直接返回到根
-        if targetIndex == 0 {
-            setCapsuleVisible(false)
-            pageLifecycle?.onUnload(webviewId: app!.getCurrentWebViewId())
-            tabBarContainerController?.destroy()
-            tabBarContainerController = nil
-            pageRecords.removeAll()
-            navigationController.popToRootViewController(animated: animated)
-            return
-        }
-
-        // 处理返回逻辑
-        let removalCount: Int
-        if miniProgramBaseViewControllers != nil {
-            removalCount = min(max(delta, 1), max(pageRecords.count - 1, 0))
-        } else {
-            removalCount = max(delta, 1)
-        }
+        // 处理返回逻辑：最多弹到只剩栈底那条记录，首页记录必须留下——pageRecords 是
+        // getCurrentWebViewId 的唯一来源，清空它会让之后的前后台切换和跨小程序派发拿到 -1。
+        let removalCount = min(max(delta, 1), max(pageRecords.count - 1, 0))
         for _ in 0..<removalCount {
             if navigationController.viewControllers.count <= 1 || pageRecords.isEmpty {
                 break
@@ -560,7 +610,7 @@ public class DMPNavigator: NSObject {
 
         // 显示前一个页面
         if let previousPageRecord = pageRecords.last {
-            pageLifecycle?.onShow(webviewId: previousPageRecord.webViewId)
+            dispatchPageShow(webViewId: previousPageRecord.webViewId)
         }
     }
 
@@ -646,7 +696,7 @@ public class DMPNavigator: NSObject {
             let viewControllers = [pageController]
             navigationController.setViewControllers(viewControllers, animated: false)
 
-            pageLifecycle?.onShow(webviewId: pageController.getWebView().getWebViewId())
+            dispatchPageShow(webViewId: pageController.getWebView().getWebViewId())
 
             return
         }
@@ -678,7 +728,7 @@ public class DMPNavigator: NSObject {
         viewControllers.removeLast()
         viewControllers.append(pageController)
         navigationController.setViewControllers(viewControllers, animated: false)
-        pageLifecycle?.onShow(webviewId: pageController.getWebView().getWebViewId())
+        dispatchPageShow(webViewId: pageController.getWebView().getWebViewId())
     }
 
     @MainActor
@@ -697,7 +747,7 @@ public class DMPNavigator: NSObject {
 
         navigationController.view.endEditing(true)
         let hostControllers = hostViewControllers(in: navigationController)
-        clearMiniProgramPageState()
+        clearMiniProgramPageState(reason: .routing)
 
         await launch(to: path, query: query, animated: false, showsLaunchLoading: false)
         guard isActiveNavigationOwner() else { return }
@@ -741,8 +791,10 @@ public class DMPNavigator: NSObject {
         // API success/complete and presentation-out lifecycle must all reach
         // the old service before its engine is destroyed in prepareRuntime.
         onAccepted()
-        notifyPresentOut()
-        clearMiniProgramPageState()
+        notifyRuntimeTeardownOut()
+        // restart 是「关掉再重开」而不是一次路由：上面已经发过 App.onHide，
+        // 旧运行时紧接着整体销毁，所以和退出同源，不补 onUnload。
+        clearMiniProgramPageState(reason: .exit)
         pageControllers.forEach { $0.destroy() }
 
         guard let launchConfig = await prepareRuntime() else {
@@ -779,7 +831,7 @@ public class DMPNavigator: NSObject {
         notifyPresentOut()
         setCapsuleVisible(false)
         let hostControllers = hostViewControllers(in: navigationController)
-        clearMiniProgramPageState()
+        clearMiniProgramPageState(reason: .exit)
 
         if hostControllers.isEmpty {
             navigationController.dismiss(animated: animated, completion: completion)
@@ -838,7 +890,7 @@ public class DMPNavigator: NSObject {
                let previousRecord,
                previousRecord.webViewId != tabBarController.pageRecord(at: targetIndex)?.webViewId
             {
-                pageLifecycle?.onHide(webviewId: previousRecord.webViewId)
+                dispatchPageHide(webViewId: previousRecord.webViewId)
             }
 
             guard let currentRecord = await tabBarController.selectTab(index: targetIndex, query: query) else {
@@ -849,7 +901,7 @@ public class DMPNavigator: NSObject {
             updateRootTabRecord(currentRecord)
 
             if !wasPreviousTabVisible || previousRecord?.webViewId != currentRecord.webViewId {
-                pageLifecycle?.onShow(webviewId: currentRecord.webViewId)
+                dispatchPageShow(webViewId: currentRecord.webViewId)
             }
 
             tabBarContainerController = tabBarController
@@ -884,7 +936,7 @@ public class DMPNavigator: NSObject {
         nextViewControllers.append(tabBarController)
         navigationController.setViewControllers(nextViewControllers, animated: animated)
 
-        pageLifecycle?.onShow(webviewId: pageRecord.webViewId)
+        dispatchPageShow(webViewId: pageRecord.webViewId)
         return true
     }
 

--- a/iOS/diminaTests/DMPNavigatorCapsuleTests.swift
+++ b/iOS/diminaTests/DMPNavigatorCapsuleTests.swift
@@ -145,6 +145,426 @@ final class DMPNavigatorCapsuleTests: XCTestCase {
         XCTAssertFalse(navigationController.viewControllers.contains { $0 === targetRoot })
     }
 
+    /// 首页上的返回是一次退出，不是路由：微信没有 App 级销毁生命周期，关闭走
+    /// onAppEnterBackground(mode: close)，服务侧只看到 App.onHide。
+    func testBackOnTheEntryPageExitsToTheHostAndDispatchesAppHide() async throws {
+        let appConfig = DMPAppConfig(appName: "exit", appId: "exit-\(UUID().uuidString)")
+        let app = DMPApp(appConfig: appConfig, appIndex: -1)
+        let service = DMPService(app: app)
+        app.service = service
+        defer {
+            app.service = nil
+            service.destroy()
+            app.render = nil
+        }
+        app.render = DMPRender(app: app)
+        let recorder = await recordContainerMessages(on: service, as: "captureEntryPageExit")
+        app.markAppRuntimeReady()
+
+        let navigator = try XCTUnwrap(app.getNavigator())
+        let host = UIViewController()
+        let entryPage = DMPPageController(
+            pagePath: "pages/index/index",
+            query: nil,
+            appConfig: appConfig,
+            app: app,
+            navigator: navigator,
+            isRoot: true
+        )
+        let navigationController = UINavigationController()
+        navigationController.setViewControllers([host, entryPage], animated: false)
+        navigator.setup(navigationController: navigationController)
+
+        navigator.navigateBack(animated: false)
+        // 页面控制器的销毁跟着转场走，退出返回后才发生。断言必须跨过它，否则那条迟到的
+        // pageUnload 落在测量窗口之外，看起来像没发生过。
+        entryPage.destroy()
+        await service.drainPendingContainerMessages()
+
+        XCTAssertEqual(recorder.types, ["appHide"])
+        XCTAssertEqual(navigationController.viewControllers.count, 1)
+        XCTAssertTrue(navigationController.viewControllers[0] === host)
+    }
+
+    /// closeMiniProgram 拆的是整个页面栈，页面控制器随转场销毁。退出不是路由，
+    /// 这条销毁路径也不能补 pageUnload。
+    func testClosingTheMiniProgramNeverUnloadsPagesEvenAfterTheTransitionDestroysThem() async throws {
+        let appConfig = DMPAppConfig(appName: "close", appId: "close-\(UUID().uuidString)")
+        let app = DMPApp(appConfig: appConfig, appIndex: -1)
+        let service = DMPService(app: app)
+        app.service = service
+        defer {
+            app.service = nil
+            service.destroy()
+            app.render = nil
+        }
+        app.render = DMPRender(app: app)
+        let recorder = await recordContainerMessages(on: service, as: "captureCloseTeardown")
+        app.markAppRuntimeReady()
+
+        let navigator = try XCTUnwrap(app.getNavigator())
+        let host = UIViewController()
+        let entryPage = DMPPageController(
+            pagePath: "pages/index/index",
+            query: nil,
+            appConfig: appConfig,
+            app: app,
+            navigator: navigator,
+            isRoot: true
+        )
+        let detailPage = DMPPageController(
+            pagePath: "pages/detail/index",
+            query: nil,
+            appConfig: appConfig,
+            app: app,
+            navigator: navigator,
+            isRoot: false
+        )
+        let navigationController = UINavigationController()
+        navigationController.setViewControllers([host, entryPage, detailPage], animated: false)
+        navigator.setup(navigationController: navigationController)
+
+        navigator.closeMiniProgram(animated: false) {}
+        entryPage.destroy()
+        detailPage.destroy()
+        await service.drainPendingContainerMessages()
+
+        XCTAssertFalse(recorder.types.contains("pageUnload"))
+    }
+
+    /// 冷重启是「关掉再重开」而不是一次路由：旧运行时整体销毁，旧页面不补 onUnload。
+    func testReloadingTheRuntimeNeverUnloadsTheOldPages() async throws {
+        let appConfig = DMPAppConfig(appName: "reload", appId: "reload-\(UUID().uuidString)")
+        let app = DMPApp(appConfig: appConfig, appIndex: -1)
+        let service = DMPService(app: app)
+        app.service = service
+        defer {
+            app.service = nil
+            service.destroy()
+            app.render = nil
+        }
+        app.render = DMPRender(app: app)
+        let recorder = await recordContainerMessages(on: service, as: "captureReloadTeardown")
+        app.markAppRuntimeReady()
+
+        let navigator = try XCTUnwrap(app.getNavigator())
+        let host = UIViewController()
+        let entryPage = DMPPageController(
+            pagePath: "pages/index/index",
+            query: nil,
+            appConfig: appConfig,
+            app: app,
+            navigator: navigator,
+            isRoot: true
+        )
+        let navigationController = UINavigationController()
+        navigationController.setViewControllers([host, entryPage], animated: false)
+        navigator.setup(navigationController: navigationController)
+
+        // prepareRuntime 返回 nil：这条用例只看拆掉旧页面这一半，不需要真的建出新运行时。
+        let reloaded = await navigator.reloadMiniProgram(animated: false) { nil }
+        entryPage.destroy()
+        await service.drainPendingContainerMessages()
+
+        XCTAssertFalse(reloaded)
+        XCTAssertFalse(recorder.types.contains("pageUnload"))
+    }
+
+    /// Tab 页经 DMPTabBarContainerController.destroy() 走同一条销毁路径，退出时同样不发 pageUnload。
+    func testClosingTheMiniProgramNeverUnloadsTabPages() async throws {
+        let appConfig = DMPAppConfig(appName: "tab-exit", appId: "tab-exit-\(UUID().uuidString)")
+        let app = DMPApp(appConfig: appConfig, appIndex: -1)
+        let service = DMPService(app: app)
+        app.service = service
+        defer {
+            app.service = nil
+            service.destroy()
+            app.render = nil
+        }
+        app.render = DMPRender(app: app)
+        let recorder = await recordContainerMessages(on: service, as: "captureTabExitTeardown")
+        app.markAppRuntimeReady()
+
+        let navigator = try XCTUnwrap(app.getNavigator())
+        let tabBarConfig = DMPTabBarConfig(
+            color: "#999999",
+            selectedColor: "#000000",
+            borderStyle: "black",
+            backgroundColor: "#FFFFFF",
+            list: [
+                DMPTabBarItem(
+                    pagePath: "pages/home/index",
+                    iconPath: "",
+                    selectedIconPath: "",
+                    text: "Home"
+                ),
+            ]
+        )
+        let tabBarController = DMPTabBarContainerController(
+            initialPath: "pages/home/index",
+            query: nil,
+            appConfig: appConfig,
+            app: app,
+            navigator: navigator,
+            tabBarConfig: tabBarConfig,
+            showsLaunchLoading: false
+        )
+        let preparedTab = await tabBarController.prepareInitialTab()
+        let record = try XCTUnwrap(preparedTab)
+        XCTAssertGreaterThan(record.webViewId, 0)
+
+        let host = UIViewController()
+        let navigationController = UINavigationController()
+        navigationController.setViewControllers([host, tabBarController], animated: false)
+        navigator.setup(navigationController: navigationController)
+
+        navigator.closeMiniProgram(animated: false) {}
+        tabBarController.destroy()
+        await service.drainPendingContainerMessages()
+
+        XCTAssertFalse(recorder.types.contains("pageUnload"))
+    }
+
+    /// 反过来的那一半：路由确实卸载页面，销毁路径照常发 pageUnload。
+    func testRoutingTeardownStillUnloadsThePage() async throws {
+        let appConfig = DMPAppConfig(appName: "routing", appId: "routing-\(UUID().uuidString)")
+        let app = DMPApp(appConfig: appConfig, appIndex: -1)
+        let service = DMPService(app: app)
+        app.service = service
+        defer {
+            app.service = nil
+            service.destroy()
+            app.render = nil
+        }
+        app.render = DMPRender(app: app)
+        let recorder = await recordContainerMessages(on: service, as: "captureRoutingTeardown")
+        app.markAppRuntimeReady()
+
+        let navigator = try XCTUnwrap(app.getNavigator())
+        let page = DMPPageController(
+            pagePath: "pages/detail/index",
+            query: nil,
+            appConfig: appConfig,
+            app: app,
+            navigator: navigator,
+            isRoot: false
+        )
+
+        page.destroy()
+        await service.drainPendingContainerMessages()
+
+        XCTAssertTrue(recorder.types.contains("pageUnload"))
+    }
+
+    /// guest 只能从 exitMiniProgram / navigateBackMiniProgram 退出——那里才把 scene 1038 和
+    /// referrerInfo 交还 opener。首页上的返回在微信同样是失败，既不派发生命周期也不动栈。
+    func testBackOnTheEntryPageOfAGuestMiniProgramChangesNothing() async throws {
+        let appConfig = DMPAppConfig(appName: "guest", appId: "guest-\(UUID().uuidString)")
+        let app = DMPApp(appConfig: appConfig, appIndex: -1)
+        let service = DMPService(app: app)
+        app.service = service
+        defer {
+            app.service = nil
+            service.destroy()
+            app.render = nil
+        }
+        app.render = DMPRender(app: app)
+        let recorder = await recordContainerMessages(on: service, as: "captureGuestEntryPageBack")
+        app.markAppRuntimeReady()
+
+        let navigator = try XCTUnwrap(app.getNavigator())
+        let host = UIViewController()
+        let openerPage = DMPPageController(
+            pagePath: "pages/opener/index",
+            query: nil,
+            appConfig: appConfig,
+            app: app,
+            navigator: navigator,
+            isRoot: true
+        )
+        let targetPage = DMPPageController(
+            pagePath: "pages/target/index",
+            query: nil,
+            appConfig: appConfig,
+            app: app,
+            navigator: navigator,
+            isRoot: true
+        )
+        defer {
+            openerPage.destroy()
+            targetPage.destroy()
+        }
+        let navigationController = UINavigationController()
+        navigationController.setViewControllers([host, openerPage, targetPage], animated: false)
+        navigator.setup(
+            navigationController: navigationController,
+            preserving: [host, openerPage]
+        )
+
+        navigator.navigateBack(animated: false)
+        await service.drainPendingContainerMessages()
+
+        XCTAssertEqual(recorder.types, [])
+        XCTAssertEqual(navigationController.viewControllers.count, 3)
+        XCTAssertTrue(navigationController.viewControllers[2] === targetPage)
+    }
+
+    /// 跨小程序打开时，目标从拿到导航所有权到 service 建起来之间有一段窗口。系统在这段
+    /// 窗口里进后台，App.onHide 的接收方已经是目标，但它还没有 service——直接发就整条
+    /// 丢了，小程序会在后台以为自己仍在前台。
+    func testASystemHideDuringLaunchReachesTheServiceOnceItExists() async throws {
+        let appConfig = DMPAppConfig(appName: "late", appId: "late-\(UUID().uuidString)")
+        let app = DMPApp(appConfig: appConfig, appIndex: -1)
+
+        await MainActor.run { app.notifyMiniProgramHide() }
+
+        let service = DMPService(app: app)
+        let recorder = await recordContainerMessages(on: service, as: "captureLateService")
+        defer {
+            app.service = nil
+            service.destroy()
+        }
+        app.service = service
+        // service 建起来还不够：service.js 求值完、DiminaServiceBridge 注册之后才收得到消息。
+        app.markAppRuntimeReady()
+        await service.drainPendingContainerMessages()
+
+        XCTAssertEqual(recorder.types, ["appHide"])
+    }
+
+    /// service 存在不等于收得到消息：`initService` 只建引擎，`loadBundle` 之后
+    /// `DiminaServiceBridge` 才存在。这中间投递的消息会丢在引擎队列里，且账本会把它
+    /// 记成「已送达」，就绪后再也补不回来——所以就绪之前只记账不派发。
+    func testAHideBetweenServiceCreationAndBundleEvaluationWaitsForReadiness() async throws {
+        let appConfig = DMPAppConfig(appName: "window", appId: "window-\(UUID().uuidString)")
+        let app = DMPApp(appConfig: appConfig, appIndex: -1)
+        let service = DMPService(app: app)
+        app.service = service
+        defer {
+            app.service = nil
+            service.destroy()
+        }
+        let recorder = await recordContainerMessages(on: service, as: "captureLaunchWindow")
+
+        await MainActor.run { app.notifyMiniProgramHide() }
+        await service.drainPendingContainerMessages()
+        XCTAssertEqual(recorder.types, [])
+
+        app.markAppRuntimeReady()
+        await service.drainPendingContainerMessages()
+        XCTAssertEqual(recorder.types, ["appHide"])
+    }
+
+    /// App.onShow/onHide 在微信里严格交替。同一个状态第二次到达（退出已经派发过
+    /// hide，紧接着系统又进后台）不再派发。
+    func testTheSameAppVisibilityIsNeverDispatchedTwice() async throws {
+        let appConfig = DMPAppConfig(appName: "ledger", appId: "ledger-\(UUID().uuidString)")
+        let app = DMPApp(appConfig: appConfig, appIndex: -1)
+        let service = DMPService(app: app)
+        app.service = service
+        defer {
+            app.service = nil
+            service.destroy()
+        }
+        let recorder = await recordContainerMessages(on: service, as: "captureVisibilityLedger")
+        app.markAppRuntimeReady()
+
+        await MainActor.run {
+            app.notifyMiniProgramShow()
+            app.notifyMiniProgramHide()
+            app.notifyMiniProgramHide()
+            app.notifyMiniProgramShow()
+            app.notifyMiniProgramShow()
+        }
+        await service.drainPendingContainerMessages()
+
+        XCTAssertEqual(recorder.types, ["appHide", "appShow"])
+    }
+
+    /// bundle 求值完不等于 service 侧 App 实例存在：App 由 loader 的 `modRequire('app')` 建出来，
+    /// 容器只有收到 `serviceResourceLoaded` 才知道那一步跑完了。更早把账本置为就绪，窗口期欠下的
+    /// appHide 会被 service 侧 `runtime.appHide()` 的 `this.app` 判空静默丢掉。
+    func testTheRuntimeBecomesReadyOnlyWhenTheServiceReportsItsResourceLoaded() async throws {
+        let appConfig = DMPAppConfig(appName: "ready", appId: "ready-\(UUID().uuidString)")
+        let app = DMPApp(appConfig: appConfig, appIndex: -1)
+        let service = DMPService(app: app)
+        app.service = service
+        defer {
+            app.service = nil
+            service.destroy()
+        }
+        let recorder = await recordContainerMessages(on: service, as: "captureReadySignal")
+
+        await MainActor.run { app.notifyMiniProgramHide() }
+        await service.drainPendingContainerMessages()
+        XCTAssertEqual(recorder.types, [])
+
+        _ = DMPChannelProxy.messageHandler(
+            type: "serviceResourceLoaded",
+            body: DMPMap(["bridgeId": 0]),
+            target: "service",
+            app: app
+        )
+        await service.drainPendingContainerMessages()
+        XCTAssertEqual(recorder.types, ["appHide"])
+    }
+
+    /// restart 发给旧运行时的 App.onHide 是终态，不是一次容器隐藏。把它记成容器意图，新运行时
+    /// 就绪后会先收到一条并不该收的 appHide，随后真正的 Home 键又被去重吃掉。
+    func testARuntimeRestartDoesNotHandTheNewRuntimeAStaleHide() async throws {
+        let appConfig = DMPAppConfig(appName: "restart", appId: "restart-\(UUID().uuidString)")
+        let app = DMPApp(appConfig: appConfig, appIndex: -1)
+        let oldService = DMPService(app: app)
+        app.service = oldService
+        app.markAppRuntimeReady()
+        await MainActor.run { app.notifyRuntimeTeardownHide() }
+
+        let newService = DMPService(app: app)
+        let recorder = await recordContainerMessages(on: newService, as: "captureRestartedRuntime")
+        app.service = newService
+        oldService.destroy()
+        defer {
+            app.service = nil
+            newService.destroy()
+        }
+
+        app.markAppRuntimeReady()
+        await newService.drainPendingContainerMessages()
+        // 新 Worker 自己会派发 onLaunch/onShow，容器一直可见，这里不该再补任何东西。
+        XCTAssertEqual(recorder.types, [])
+
+        await MainActor.run { app.notifyMiniProgramHide() }
+        await newService.drainPendingContainerMessages()
+        XCTAssertEqual(recorder.types, ["appHide"])
+    }
+
+    /// 销毁旧运行时和建起新运行时之间按 Home：这条隐藏没有可投递的目标，必须留到新运行时
+    /// 就绪时结算，否则小程序在后台以为自己仍在前台。
+    func testASystemBackgroundDuringARestartReachesTheNewRuntime() async throws {
+        let appConfig = DMPAppConfig(appName: "restartbg", appId: "restartbg-\(UUID().uuidString)")
+        let app = DMPApp(appConfig: appConfig, appIndex: -1)
+        let oldService = DMPService(app: app)
+        app.service = oldService
+        app.markAppRuntimeReady()
+        await MainActor.run {
+            app.notifyRuntimeTeardownHide()
+            app.notifyMiniProgramHide()
+        }
+
+        let newService = DMPService(app: app)
+        let recorder = await recordContainerMessages(on: newService, as: "captureRestartedBackground")
+        app.service = newService
+        oldService.destroy()
+        defer {
+            app.service = nil
+            newService.destroy()
+        }
+
+        app.markAppRuntimeReady()
+        await newService.drainPendingContainerMessages()
+        XCTAssertEqual(recorder.types, ["appHide"])
+    }
+
     func testTargetNavigatorNeverAdoptsOpenerTabBarContainer() {
         let appConfig = DMPAppConfig(appName: "tabs", appId: "tabs")
         let tabBarConfig = DMPTabBarConfig(
@@ -194,6 +614,61 @@ final class DMPNavigatorCapsuleTests: XCTestCase {
         navigationController.setViewControllers([openerTab, targetTab], animated: false)
 
         XCTAssertTrue(targetNavigator.currentTabBarContainer() === targetTab)
+    }
+
+    func testLaunchReturnsFalseWithoutANavigationController() async {
+        let navigator = DMPNavigator()
+
+        let launched = await navigator.launch(to: "pages/index/index")
+
+        XCTAssertFalse(launched)
+    }
+
+    func testLaunchReturnsFalseWhenNavigatorIsNotTheActiveOwner() async {
+        let navigationController = UINavigationController()
+        navigationController.loadViewIfNeeded()
+        let firstNavigator = DMPNavigator()
+        firstNavigator.setup(navigationController: navigationController)
+        let secondNavigator = DMPNavigator()
+        secondNavigator.setup(navigationController: navigationController)
+        XCTAssertFalse(firstNavigator.isActiveNavigationOwner())
+
+        let launched = await firstNavigator.launch(to: "pages/index/index")
+
+        XCTAssertFalse(launched)
+    }
+
+    func testPrepareInitialTabReturnsNilWithoutAnApp() async {
+        let appConfig = DMPAppConfig(appName: "tabs", appId: "tabs-\(UUID().uuidString)")
+        let tabBarConfig = DMPTabBarConfig(
+            color: "#999999",
+            selectedColor: "#000000",
+            borderStyle: "black",
+            backgroundColor: "#FFFFFF",
+            list: [
+                DMPTabBarItem(
+                    pagePath: "pages/home/index",
+                    iconPath: "",
+                    selectedIconPath: "",
+                    text: "Home"
+                ),
+            ]
+        )
+        let tabBarController = DMPTabBarContainerController(
+            initialPath: "pages/home/index",
+            query: nil,
+            appConfig: appConfig,
+            app: nil,
+            navigator: nil,
+            tabBarConfig: tabBarConfig,
+            showsLaunchLoading: false
+        )
+
+        let record = await tabBarController.prepareInitialTab()
+
+        // DMPNavigator.launch's tab-bar branch relies on this nil short-circuit
+        // to return false instead of pushing a blank tab-bar container.
+        XCTAssertNil(record)
     }
 
     func testRouteAPIRegistersMiniProgramLevelMethods() {
@@ -420,6 +895,257 @@ final class DMPNavigatorCapsuleTests: XCTestCase {
         )
     }
 
+    func testNavigateBackMiniProgramRestoresOpenerThroughTheRealManagerPath() async throws {
+        _ = RouteAPI()
+        let manager = DMPAppManager.sharedInstance()
+        let openerAppId = "opener-\(UUID().uuidString)"
+        let targetAppId = "target-\(UUID().uuidString)"
+        let opener = manager.newAppWithConfig(
+            appConfig: DMPAppConfig(appName: "opener", appId: openerAppId)
+        )
+        let target = manager.newAppWithConfig(
+            appConfig: DMPAppConfig(appName: "target", appId: targetAppId)
+        )
+        defer {
+            manager.removeApp(appId: openerAppId)
+            manager.removeApp(appId: targetAppId)
+        }
+
+        let host = UIViewController()
+        let openerPage = UIViewController()
+        let targetPage = UIViewController()
+        let navigationController = UINavigationController()
+        navigationController.setViewControllers([host, openerPage, targetPage], animated: false)
+        opener.getNavigator()?.setup(navigationController: navigationController)
+        let readOpenerEvents = await attachLifecycleCapture(to: opener)
+        // navigateToMiniProgram 先挂起 opener 再把导航所有权交给 target，opener 的
+        // App.onHide 就在这一步派发；跨小程序返回时的 onShow 必须与它配对。
+        opener.getNavigator()?.suspendForMiniProgramNavigation()
+        target.getNavigator()?.setup(
+            navigationController: navigationController,
+            preserving: [host, openerPage]
+        )
+        XCTAssertTrue(target.getNavigator()?.isActiveNavigationOwner() ?? false)
+
+        manager.markOpenedByMiniProgramForTesting(target: target, opener: opener)
+
+        let handler = try XCTUnwrap(DMPContainerApi.getHandler(for: "navigateBackMiniProgram"))
+        let completed = expectation(description: "navigateBackMiniProgram completes")
+        var callbackTypes: [DMPBridgeCallbackType] = []
+        _ = handler(
+            DMPBridgeParam(value: [:]),
+            DMPBridgeEnv(appIndex: target.getAppIndex(), appId: targetAppId, webViewId: 1)
+        ) { _, callbackType in
+            callbackTypes.append(callbackType)
+            if callbackType == .complete {
+                completed.fulfill()
+            }
+        }
+        await fulfillment(of: [completed], timeout: 1)
+        XCTAssertEqual(callbackTypes, [.success, .complete])
+
+        // navigateBackMiniProgram's success callback fires via onAccepted before
+        // closeMiniProgram's CATransaction completion, destroy(), and restoreOpener()
+        // run. withMiniProgramOperation only clears its in-flight flag once that whole
+        // chain returns, so poll it instead of trusting the success/complete callbacks
+        // for ordering.
+        while manager.isMiniProgramOperationInFlight() {
+            await Task.yield()
+        }
+        await opener.service?.drainPendingContainerMessages()
+        waitForNavigationStack(navigationController, toSettleAt: 2)
+
+        // The opener's stack is restored and it becomes the active owner again.
+        XCTAssertEqual(navigationController.viewControllers.count, 2)
+        XCTAssertTrue(navigationController.viewControllers[0] === host)
+        XCTAssertTrue(navigationController.viewControllers[1] === openerPage)
+        XCTAssertTrue(opener.getNavigator()?.isActiveNavigationOwner() ?? false)
+
+        // The opener actually receives an appShow carrying the 1038 "mini
+        // program back" scene and the target's appId as referrer.
+        let openerEvents = readOpenerEvents()
+        XCTAssertEqual(openerEvents.map { $0["type"] as? String }, ["appHide", "appShow"])
+        let showBody = openerEvents.last?["body"] as? [String: Any]
+        XCTAssertEqual(showBody?["scene"] as? Int, DMPScene.fromMiniProgramBack.rawValue)
+        let referrerInfo = showBody?["referrerInfo"] as? [String: Any]
+        XCTAssertEqual(referrerInfo?["appId"] as? String, targetAppId)
+
+        // A successful navigateBackMiniProgram both destroys the target and
+        // consumes the opener context; repeating it against the same index
+        // now fails because the target app itself is gone.
+        let repeatCompleted = expectation(description: "second navigateBackMiniProgram completes")
+        var repeatFailure: DMPMap?
+        _ = handler(
+            DMPBridgeParam(value: [:]),
+            DMPBridgeEnv(appIndex: target.getAppIndex(), appId: targetAppId, webViewId: 1)
+        ) { result, callbackType in
+            if callbackType == .fail {
+                repeatFailure = result
+            } else if callbackType == .complete {
+                repeatCompleted.fulfill()
+            }
+        }
+        await fulfillment(of: [repeatCompleted], timeout: 1)
+        XCTAssertEqual(
+            repeatFailure?.get("errMsg") as? String,
+            "navigateBackMiniProgram:fail invalid app"
+        )
+    }
+
+    func testOpenerRestoredWhileHostIsBackgroundedGetsItsAppShowOnTheRealForeground() async throws {
+        _ = RouteAPI()
+        let manager = DMPAppManager.sharedInstance()
+        let openerAppId = "opener-\(UUID().uuidString)"
+        let targetAppId = "target-\(UUID().uuidString)"
+        let opener = manager.newAppWithConfig(
+            appConfig: DMPAppConfig(appName: "opener", appId: openerAppId)
+        )
+        let target = manager.newAppWithConfig(
+            appConfig: DMPAppConfig(appName: "target", appId: targetAppId)
+        )
+        defer {
+            // 宿主可见性是进程级单例状态，失败退出时也要还原，否则污染后续用例。
+            NotificationCenter.default.post(
+                name: UIApplication.willEnterForegroundNotification,
+                object: nil
+            )
+            manager.removeApp(appId: openerAppId)
+            manager.removeApp(appId: targetAppId)
+        }
+
+        let host = UIViewController()
+        let openerPage = UIViewController()
+        let targetPage = UIViewController()
+        let navigationController = UINavigationController()
+        navigationController.setViewControllers([host, openerPage, targetPage], animated: false)
+        opener.getNavigator()?.setup(navigationController: navigationController)
+        let readOpenerEvents = await attachLifecycleCapture(to: opener)
+        opener.getNavigator()?.suspendForMiniProgramNavigation()
+        target.getNavigator()?.setup(
+            navigationController: navigationController,
+            preserving: [host, openerPage]
+        )
+        manager.markOpenedByMiniProgramForTesting(target: target, opener: opener)
+
+        // 用户在返回过程中把宿主切走：跨小程序返回可以整个发生在后台。
+        NotificationCenter.default.post(
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+        await waitForHostVisible(false, on: manager)
+        XCTAssertFalse(manager.isHostVisibleForTesting())
+
+        let handler = try XCTUnwrap(DMPContainerApi.getHandler(for: "navigateBackMiniProgram"))
+        let completed = expectation(description: "navigateBackMiniProgram completes")
+        _ = handler(
+            DMPBridgeParam(value: [:]),
+            DMPBridgeEnv(appIndex: target.getAppIndex(), appId: targetAppId, webViewId: 1)
+        ) { _, callbackType in
+            if callbackType == .complete {
+                completed.fulfill()
+            }
+        }
+        await fulfillment(of: [completed], timeout: 1)
+        while manager.isMiniProgramOperationInFlight() {
+            await Task.yield()
+        }
+        await opener.service?.drainPendingContainerMessages()
+        waitForNavigationStack(navigationController, toSettleAt: 2)
+
+        // opener 拿回了展示关系，但宿主整体不可见——此刻派发 App.onShow 会让账本以为
+        // 它已经显示，宿主真正回到前台时那条 show 就被去重掉。
+        XCTAssertTrue(opener.getNavigator()?.isActiveNavigationOwner() ?? false)
+        XCTAssertEqual(readOpenerEvents().map { $0["type"] as? String }, ["appHide"])
+
+        // 宿主回到前台，这才是本次返回真正的 App.onShow：它必须带上返回场景值和 referrerInfo，
+        // 而不是 opener 自己的启动场景。
+        NotificationCenter.default.post(
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
+        await waitForHostVisible(true, on: manager)
+        await opener.service?.drainPendingContainerMessages()
+
+        let openerEvents = readOpenerEvents()
+        XCTAssertEqual(openerEvents.map { $0["type"] as? String }, ["appHide", "appShow"])
+        let showBody = openerEvents.last?["body"] as? [String: Any]
+        XCTAssertEqual(showBody?["scene"] as? Int, DMPScene.fromMiniProgramBack.rawValue)
+        let referrerInfo = showBody?["referrerInfo"] as? [String: Any]
+        XCTAssertEqual(referrerInfo?["appId"] as? String, targetAppId)
+    }
+
+    func testExitMiniProgramRestoresOpenerThroughTheRealManagerPath() async throws {
+        _ = RouteAPI()
+        let manager = DMPAppManager.sharedInstance()
+        let openerAppId = "opener-\(UUID().uuidString)"
+        let targetAppId = "target-\(UUID().uuidString)"
+        let opener = manager.newAppWithConfig(
+            appConfig: DMPAppConfig(appName: "opener", appId: openerAppId)
+        )
+        let target = manager.newAppWithConfig(
+            appConfig: DMPAppConfig(appName: "target", appId: targetAppId)
+        )
+        defer {
+            manager.removeApp(appId: openerAppId)
+            manager.removeApp(appId: targetAppId)
+        }
+
+        let host = UIViewController()
+        let openerPage = UIViewController()
+        let targetPage = UIViewController()
+        let navigationController = UINavigationController()
+        navigationController.setViewControllers([host, openerPage, targetPage], animated: false)
+        opener.getNavigator()?.setup(navigationController: navigationController)
+        let readOpenerEvents = await attachLifecycleCapture(to: opener)
+        // navigateToMiniProgram 先挂起 opener 再把导航所有权交给 target，opener 的
+        // App.onHide 就在这一步派发；跨小程序返回时的 onShow 必须与它配对。
+        opener.getNavigator()?.suspendForMiniProgramNavigation()
+        target.getNavigator()?.setup(
+            navigationController: navigationController,
+            preserving: [host, openerPage]
+        )
+
+        manager.markOpenedByMiniProgramForTesting(target: target, opener: opener)
+
+        let handler = try XCTUnwrap(DMPContainerApi.getHandler(for: "exitMiniProgram"))
+        let completed = expectation(description: "exitMiniProgram completes")
+        var callbackTypes: [DMPBridgeCallbackType] = []
+        _ = handler(
+            DMPBridgeParam(value: [:]),
+            DMPBridgeEnv(appIndex: target.getAppIndex(), appId: targetAppId, webViewId: 1)
+        ) { _, callbackType in
+            callbackTypes.append(callbackType)
+            if callbackType == .complete {
+                completed.fulfill()
+            }
+        }
+        await fulfillment(of: [completed], timeout: 1)
+        XCTAssertEqual(callbackTypes, [.success, .complete])
+
+        // exitMiniProgram's success callback fires via onAccepted before
+        // closeMiniProgram's CATransaction completion, destroy(), and restoreOpener()
+        // run. withMiniProgramOperation only clears its in-flight flag once that whole
+        // chain returns, so poll it instead of trusting the success/complete callbacks
+        // for ordering.
+        while manager.isMiniProgramOperationInFlight() {
+            await Task.yield()
+        }
+        await opener.service?.drainPendingContainerMessages()
+        waitForNavigationStack(navigationController, toSettleAt: 2)
+
+        XCTAssertEqual(navigationController.viewControllers.count, 2)
+        XCTAssertTrue(opener.getNavigator()?.isActiveNavigationOwner() ?? false)
+
+        // exitMiniProgram carries no extraData, unlike navigateBackMiniProgram.
+        let openerEvents = readOpenerEvents()
+        XCTAssertEqual(openerEvents.map { $0["type"] as? String }, ["appHide", "appShow"])
+        let showBody = openerEvents.last?["body"] as? [String: Any]
+        XCTAssertEqual(showBody?["scene"] as? Int, DMPScene.fromMiniProgramBack.rawValue)
+        let referrerInfo = showBody?["referrerInfo"] as? [String: Any]
+        XCTAssertEqual(referrerInfo?["appId"] as? String, targetAppId)
+        XCTAssertNil(referrerInfo?["extraData"])
+    }
+
     func testRestartMiniProgramRequiresPathThroughUnifiedCallbacks() throws {
         _ = RouteAPI()
         let handler = try XCTUnwrap(DMPContainerApi.getHandler(for: "restartMiniProgram"))
@@ -560,6 +1286,99 @@ final class DMPNavigatorCapsuleTests: XCTestCase {
             (receivedBody?["referrerInfo"] as? [String: Any])?["appId"] as? String,
             "target"
         )
+    }
+
+    func testNavigateBackMiniProgramLifecycleRunsOnceInOrder() async {
+        let events = await captureMiniProgramLifecycle(rounds: [(
+            DMPScene.fromMiniProgramBack.rawValue,
+            ["appId": "target", "extraData": ["source": "navigateBackMiniProgram"]]
+        )])
+
+        XCTAssertEqual(events, ["pageHide", "appHide", "appShow", "pageShow"])
+    }
+
+    func testExitMiniProgramLifecycleRunsOnceInOrder() async {
+        let events = await captureMiniProgramLifecycle(rounds: [(
+            DMPScene.fromMiniProgramBack.rawValue,
+            ["appId": "target"]
+        )])
+
+        XCTAssertEqual(events, ["pageHide", "appHide", "appShow", "pageShow"])
+    }
+
+    func testFailedTargetLaunchRollsLifecycleBackOnceInOrder() async {
+        let events = await captureMiniProgramLifecycle(rounds: [(nil, nil)])
+
+        XCTAssertEqual(events, ["pageHide", "appHide", "appShow", "pageShow"])
+    }
+
+    func testCrossMiniProgramLifecycleRemainsBalancedAcrossTwoRounds() async {
+        let events = await captureMiniProgramLifecycle(rounds: [
+            (DMPScene.fromMiniProgramBack.rawValue, ["appId": "target"]),
+            (DMPScene.fromMiniProgramBack.rawValue, ["appId": "target"]),
+        ])
+
+        XCTAssertEqual(events, [
+            "pageHide", "appHide", "appShow", "pageShow",
+            "pageHide", "appHide", "appShow", "pageShow",
+        ])
+    }
+
+    func testNativeCrossMiniProgramEntriesUseTheRoutePageDispatcher() throws {
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let iosNavigator = try String(
+            contentsOf: repositoryRoot.appendingPathComponent(
+                "iOS/dimina/DiminaKit/Navigator/DMPNavigator.swift"
+            ),
+            encoding: .utf8
+        )
+        let iosApp = try String(
+            contentsOf: repositoryRoot.appendingPathComponent(
+                "iOS/dimina/DiminaKit/App/DMPApp.swift"
+            ),
+            encoding: .utf8
+        )
+        let harmonyApp = try String(
+            contentsOf: repositoryRoot.appendingPathComponent(
+                "harmony/dimina/src/main/ets/DApp/DMPApp.ets"
+            ),
+            encoding: .utf8
+        )
+        let harmonyNavigator = try String(
+            contentsOf: repositoryRoot.appendingPathComponent(
+                "harmony/dimina/src/main/ets/Navigator/DMPNavigator.ets"
+            ),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(iosNavigator.contains("dispatchPageHide(webViewId:"))
+        XCTAssertTrue(iosNavigator.contains("dispatchPageShow(webViewId:"))
+        XCTAssertTrue(iosNavigator.contains("app?.notifyMiniProgramHide()"))
+        XCTAssertTrue(iosNavigator.contains("app?.notifyMiniProgramShow(scene:"))
+        XCTAssertTrue(iosApp.contains("notifyMiniProgramHide(webViewId: getCurrentWebViewId())"))
+        XCTAssertTrue(iosApp.contains("webViewId: getCurrentWebViewId(),"))
+        XCTAssertTrue(harmonyApp.contains("navigatorManager.dispatchPageHide(bridgeId)"))
+        XCTAssertTrue(harmonyApp.contains("navigatorManager.dispatchPageShow(bridgeId)"))
+        XCTAssertTrue(harmonyNavigator.contains("dispatchPageHide(webViewId: number)"))
+        XCTAssertTrue(harmonyNavigator.contains("dispatchPageShow(webViewId: number)"))
+        XCTAssertEqual(iosNavigator.components(separatedBy: "pageLifecycle?.onHide").count - 1, 1)
+        XCTAssertEqual(iosNavigator.components(separatedBy: "pageLifecycle?.onShow").count - 1, 1)
+        XCTAssertEqual(harmonyNavigator.components(separatedBy: "this.pageLifecycle.onHide").count - 1, 1)
+        XCTAssertEqual(harmonyNavigator.components(separatedBy: "this.pageLifecycle.onShow").count - 1, 1)
+
+        let appHide = try XCTUnwrap(harmonyApp.range(of: "type: 'appHide'"))
+        let pageHide = try XCTUnwrap(
+            harmonyApp.range(of: "navigatorManager.dispatchPageHide(bridgeId)")
+        )
+        let appShow = try XCTUnwrap(harmonyApp.range(of: "type: 'appShow'"))
+        let pageShow = try XCTUnwrap(
+            harmonyApp.range(of: "navigatorManager.dispatchPageShow(bridgeId)")
+        )
+        XCTAssertLessThan(pageHide.lowerBound, appHide.lowerBound)
+        XCTAssertLessThan(appShow.lowerBound, pageShow.lowerBound)
     }
 
     func testServiceEngineResolversStayIsolatedAfterTargetDestroy() {
@@ -850,6 +1669,124 @@ final class DMPNavigatorCapsuleTests: XCTestCase {
         webview.poolState = .loading
 
         XCTAssertEqual(loadingStates, [true, false])
+    }
+
+    /// 容器发往 service 的全部消息类型，按到达顺序记录——断言「没有派发某个生命周期」
+    /// 需要看到完整序列，只挑白名单会让多余的一条消息静默通过。
+    private final class ContainerMessageRecorder {
+        var types: [String] = []
+    }
+
+    private func recordContainerMessages(
+        on service: DMPService,
+        as methodName: String
+    ) async -> ContainerMessageRecorder {
+        let recorder = ContainerMessageRecorder()
+        service.getEngine().registerMethod(name: methodName) { value in
+            if let type = (value.toDictionary() as? [String: Any])?["type"] as? String {
+                recorder.types.append(type)
+            }
+            return nil
+        }
+        _ = await service.evaluateScript(
+            "DiminaServiceBridge.onMessage = function(message) { \(methodName)(message); };"
+        )
+        return recorder
+    }
+
+    private func captureMiniProgramLifecycle(
+        rounds: [(scene: Int?, referrerInfo: [String: Any]?)]
+    ) async -> [String] {
+        let app = DMPApp(
+            appConfig: DMPAppConfig(appName: "lifecycle", appId: "lifecycle-\(UUID().uuidString)"),
+            appIndex: -1
+        )
+        let service = DMPService(app: app)
+        app.service = service
+        defer {
+            app.service = nil
+            service.destroy()
+        }
+
+        var events: [String] = []
+        service.getEngine().registerMethod(name: "captureMiniProgramLifecycle") { value in
+            let message = value.toDictionary() as? [String: Any]
+            if let type = message?["type"] as? String,
+               ["appHide", "pageHide", "appShow", "pageShow"].contains(type)
+            {
+                events.append(type)
+            }
+            return nil
+        }
+        _ = await service.evaluateScript(
+            "DiminaServiceBridge.onMessage = function(message) { captureMiniProgramLifecycle(message); };"
+        )
+        app.markAppRuntimeReady()
+
+        for round in rounds {
+            app.notifyMiniProgramHide(webViewId: 7)
+            app.notifyMiniProgramShow(
+                webViewId: 7,
+                scene: round.scene,
+                referrerInfo: round.referrerInfo
+            )
+        }
+        await service.drainPendingContainerMessages()
+        return events
+    }
+
+    /// Wires a real `DMPService` onto `app` and captures every lifecycle
+    /// message it receives, so a test can drive `app` through the real
+    /// `DMPAppManager` navigation paths and observe what actually reaches
+    /// the service layer instead of asserting on internal call sites.
+    private func attachLifecycleCapture(to app: DMPApp) async -> () -> [[String: Any]] {
+        let service = DMPService(app: app)
+        app.service = service
+        var events: [[String: Any]] = []
+        service.getEngine().registerMethod(name: "captureMiniProgramLifecycle") { value in
+            if let message = value.toDictionary() as? [String: Any],
+               let type = message["type"] as? String,
+               ["appHide", "pageHide", "appShow", "pageShow"].contains(type)
+            {
+                events.append(message)
+            }
+            return nil
+        }
+        _ = await service.evaluateScript(
+            "DiminaServiceBridge.onMessage = function(message) { captureMiniProgramLifecycle(message); };"
+        )
+        app.markAppRuntimeReady()
+        return { events }
+    }
+
+    /// The manager closes the target with an animated pop. A navigation controller that is not
+    /// in a window can still report the pre-pop stack when `closeMiniProgram`'s CATransaction
+    /// completion - and with it the manager's in-flight flag - has already run, because the
+    /// transition itself only advances on the run loop. Spin it until the stack settles so the
+    /// assertions measure the pop rather than the transition's timing; a pop that never lands
+    /// still fails on the assertion that follows.
+    private func waitForNavigationStack(
+        _ navigationController: UINavigationController,
+        toSettleAt count: Int
+    ) {
+        let deadline = Date().addingTimeInterval(2)
+        while navigationController.viewControllers.count != count, Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+        }
+    }
+
+    /// 宿主前后台通知要经 NotificationCenter 的 main queue 和一次 MainActor Task 两跳才生效，
+    /// 只能挂起等待——同步空转 run loop 不会让这两跳跑起来。条件始终不成立时超时返回，
+    /// 由随后的断言给出失败。
+    private func waitForHostVisible(
+        _ expected: Bool,
+        on manager: DMPAppManager,
+        timeout: TimeInterval = 2
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while manager.isHostVisibleForTesting() != expected, Date() < deadline {
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
     }
 
     private func capsules(in view: UIView) -> [UIView] {


### PR DESCRIPTION
## 要统一什么

**一个小程序的 App 和页面「是否可见」，应该只有一个地方说了算：不管这次变化是谁触发的，都从同一个入口发出去；接收方（service 线程或 WebView）还没起来时，把这次变化记下来等它起来再补发，而不是直接丢掉。**

触发可见性变化的来源有四类：用户按 Home 键切前后台、小程序内部翻页、跨小程序跳转、以及小程序还在启动、运行时尚未就绪的那段窗口期。此前每端各有各的绕行路径，同一个动作在三端产生的生命周期事件并不一样。

## 修了哪些

1. **可见性由多处各自发出**。iOS/Harmony 的返回、退出、启动失败回退这几条路径绕开 navigator 自己直接发页面事件；Android 把 App 的前后台绑在单个 Activity 的 `onResume/onPause` 上，于是小程序内部翻页、系统弹窗都会被误当成「小程序进了后台」；Web 在渲染层还没就绪时先发 `AppHide`，之后再补一个没有配对的 `PageHide`。
2. **系统前后台不联动当前页面**。iOS/Harmony 按 Home 键只发 `onAppShow/onAppHide`，当前页面收不到 `Page.onShow/onHide`——微信里 App 级可见性变化本来就会带动当前页面。
3. **运行时还没准备好时，这次变化被丢掉**。Android 的 `onStart/onStop` 可能在 JsCore 建好之前触发（横竖屏切换、进程被杀后恢复），而原先取 JsCore 的调用是「没有就现场建一个」，会在主线程上同步解压并求值 service.js；Harmony 的页面事件派发依赖「当前 navigator」，栈瞬间为空时（例如正退到栈底）这次事件就没了。
4. **重启运行时会污染「容器是否可见」**。小程序 restart 时容器窗口没变，换掉的只是里面的运行时。但发给旧 service 的最后一条 `App.onHide` 走了普通的「容器隐藏」路径，顺手把「容器当前是否可见」也改成了不可见；新运行时起来后只能靠猜重设这个值。于是这段窗口期里真实发生的前后台切换丢了——按了 Home 键，小程序却以为自己还在前台，回到前台也收不到 `App.onShow`。
5. **宿主 App 自己在后台时返回来源小程序，返回场景丢失**。返回时立刻发了 `App.onShow`，账本记成「已经显示过了」；等宿主真正回到前台，那次本该发的 show 被当成重复去掉，小程序从头到尾没察觉到这次返回。
6. **关闭按钮不把用户送回来源小程序**（与上面几条没有因果关系，是评审时另外发现的）。Android 胶囊上的「×」和菜单里的「关闭小程序」直接调了 `closeMiniProgram()`，而这个函数只做一件事：把该 appId 的所有 Activity 关掉。它不会告诉来源小程序「用户当初是从你这里跳过来的、现在回来了」——微信里这份信息体现为来源小程序的 `App.onShow` 收到 `scene: 1038` 和 `referrerInfo`；它也不保证被关的小程序先收到页面隐藏、再收到 App 隐藏。改成走 `exitMiniProgram()`，这两件事由它负责。Harmony 上同样有两处。iOS 则是 `DMPNavigator.launch`/`DMPApp.openPage` 原本没有返回值，跨小程序跳转失败时上层拿不到失败信号，会把来源小程序卡在「跳走了但没有路回来」的状态，改成返回 `Bool`。
7. **退出小程序时不该发 `Page.onUnload`**。微信只在页面真的被路由换掉时才卸载页面（reLaunch / redirectTo / navigateBack / switchTab）；关闭整个小程序走的是「切到后台」那条路，只有 `App.onHide`，页面不卸载，App 也没有销毁生命周期。iOS 本来就是这样，Android 和 Harmony 不是。

## 怎么改

- **iOS / Harmony**：普通翻页和跨小程序两条路径统一走 navigator 的 `dispatchPageShow/Hide`；Harmony 的 `DMPNavigatorManager` 自己持有一个无状态的 `DMPPageLifecycle`，不再依赖「当前 navigator」。
- **Android**：App 的可见性收到 appId/JsCore 这一层记账（`AppVisibilityLedger` 放在 `JsCore` 里，因为「能不能收」取决于 service 端的 App 建好没有），页面的可见性仍由页面 Activity 管（`PageVisibilityLedger` 放在 `Bridge` 里，因为「能不能收」要同时看 WebView 和 JsCore 两边都已应答，只有 `Bridge` 同时握着这两个引用）。新增 `MiniApp.peekJsCore` 只查不建，`createBridge` 之后再由 `reconcileAppVisibilityWithCore()` 把这期间攒下的变化补发出去。
- **把「最后一条 hide」和「容器是否可见」拆开**：终态 hide 只记录「已经发出去了」，不去改容器的可见状态；运行时被换掉时也不再重放旧状态。Harmony 因此要区分「退出后又重新展示」这种容器本身也变了的情况，新增 `markRuntimeRelaunched`。
- **宿主自身的前后台状态集中在 `DMPAppManager` 一处**：宿主不可见时先把这次返回的启动参数存着，等宿主回到前台后的第一次 `App.onShow` 再带上 `scene: 1038` 和 `referrerInfo`；中途 relaunch 则丢弃这份暂存，因为场景已经不成立了。
- **「为什么关这个页面」由关闭方一路带下来**：Harmony 把它做成 `closeAllNavigators` 的必填参数，新调用点必须自己说明；Android 每个页面都是独立的 `DiminaActivity`，`onDestroy` 分不清是返回上一页还是退出小程序，所以由关闭方在 `finish()` 之前标注，默认仍按「路由」处理，系统主动回收时照常卸载页面。
- **CI**：`ios-tests.yml` 的 `paths` 加上 `harmony/**`，否则只改 Harmony 时触发不了那些比对三端文本一致性的测试。

## 验证

**单测**

| 端 | 命令 | 结果 |
| --- | --- | --- |
| Android | `./gradlew :dimina:testDebugUnitTest --rerun-tasks`（结果以 `build/test-results/**/*.xml` 为准） | 34 份报告，267 tests / 0 failures / 0 errors / 0 skipped |
| iOS | `xcodebuild test` | diminaTests 65/65，DiminaKitTests 221/221 |
| HarmonyOS | `hvigorw -p module=dimina@default test`（结果以 `test_result.txt` 为准，**测试失败时 hvigorw 仍然 exit 0**） | Tests run: 204, Failure: 0, Error: 0 |

新增的用例都反过来验证过：把对应修复逐个改回原样（还原胶囊调用、还原菜单调用、给页面事件派发加回「栈为空就返回」、去掉「为什么关页面」的判断），四次都如期转红，说明这些用例确实盯着行为而不是形式。

**真机 / 模拟器**

跨小程序返回在 Android 真机、iOS 模拟器、HarmonyOS 模拟器上各跑了两条通道（`wx.navigateBackMiniProgram` 和原生胶囊「×」），看两件事：来源小程序的 `App.onShow` 是否收到 `scene: 1038` 和 `referrerInfo`；被关的小程序是否先隐藏页面、再隐藏 App，且都早于来源小程序显示。三端两条通道都符合。

页面卸载另跑一轮：跳进目标小程序后先 `navigateTo` 打开第二页再 `navigateBack`（这是路由，第二页必须收到 `onUnload`），回到首页后再 `navigateBackMiniProgram` 退出（这不是路由，首页不该收到 `onUnload`）。三端都符合，并且把修复改回去后能在真机上重新看到那条多余的 `onUnload`。

iOS 上还有一轮由人手动操作的：脚本注入的是合成事件，而下面这几条路径的意义恰恰在于事件是系统自己发的。真按 Home 键切后台再回来，页面先收到 `onHide`、App 后收到，回来时反过来，`scene` 是 1001 没有误报成 1038；点导航栏返回按钮，被关的页面收到 `onUnload`、上一页收到 `onShow`；在第二页按 Home 键，只有第二页收到通知，第一页全程没有动静。

左边缘侧滑返回没测——iOS 端隐藏了系统导航栏自己画了一个，同时把系统返回手势关掉了（`DMPNavigator` 里的 `interactivePopGestureRecognizer?.isEnabled = false`），所以这条路径在 iOS 上不存在。

这些验证依赖仓库外自建的一对最小小程序和三端驱动脚本，**不包含在本 PR 内**。

