### PR TITLE
perf(compiler): cut dmcc view-compile time on shared-template projects

### DIFF
--- a/fe/packages/compiler/__tests__/compatibility.spec.js
+++ b/fe/packages/compiler/__tests__/compatibility.spec.js
@@ -110,4 +110,16 @@ describe('compatibility diagnostics', () => {
 		expect(warn.mock.calls[0][0]).toContain('<unknown-element>')
 		expect(warn.mock.calls[0][0]).not.toMatch(/<page-meta>|<div>|<span>|<p>|<strong>|<i>|<em>|<b>|<small>|<table>|<tbody>|<tr>|<td>/)
 	})
+
+	it('warns with the correct line number for tags scattered across many lines', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+		const lines = Array.from({ length: 20 }, (_, i) => `<text>${i}</text>`)
+		lines[0] = '<ad unit-id="first" />'
+		lines[19] = '<ad unit-id="last" />'
+		checkTemplateCompatibility(lines.join('\n'), '/pages/scattered/index.wxml')
+
+		expect(warn).toHaveBeenCalledTimes(2)
+		expect(warn.mock.calls[0][0]).toContain('/pages/scattered/index.wxml:1)')
+		expect(warn.mock.calls[1][0]).toContain('/pages/scattered/index.wxml:20)')
+	})
 })

--- a/fe/packages/compiler/__tests__/view-compiler-perf-cache.spec.js
+++ b/fe/packages/compiler/__tests__/view-compiler-perf-cache.spec.js
@@ -1,0 +1,157 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { SourceMapConsumer } from 'source-map-js'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import build from '../src/index.js'
+
+const perfCacheSpies = vi.hoisted(() => ({
+	compileTemplateCalls: [],
+	parseSyncCalls: [],
+}))
+
+vi.mock('@vue/compiler-sfc', async (importOriginal) => {
+	const actual = await importOriginal()
+	return {
+		...actual,
+		compileTemplate(options) {
+			perfCacheSpies.compileTemplateCalls.push(options.filename)
+			return actual.compileTemplate(options)
+		},
+	}
+})
+
+vi.mock('oxc-parser', async (importOriginal) => {
+	const actual = await importOriginal()
+	return {
+		...actual,
+		parseSync(...args) {
+			perfCacheSpies.parseSyncCalls.push(args)
+			return actual.parseSync(...args)
+		},
+	}
+})
+
+describe('templateRenderCache 命中路径 - 两页共享具名模板 + WXS 的完整链路', () => {
+	let tempDir
+	let originalTargetPath
+
+	const cardWxml = [
+		'<wxs src="./format.wxs" module="format" />',
+		'<template name="card"><view class="card-marker">{{format.upper(\'x\')}}</view></template>',
+		'',
+	].join('\n')
+	const formatWxs = 'module.exports = { upper: function (value) { return value } }'
+	const pageWxml = [
+		'<import src="../../templates/card" />',
+		'<view><template is="card" /></view>',
+		'<view>{{shared.expr.value}}</view>',
+		'',
+	].join('\n')
+
+	function writeProjectFile(root, relativePath, content) {
+		const fullPath = path.join(root, relativePath)
+		fs.mkdirSync(path.dirname(fullPath), { recursive: true })
+		fs.writeFileSync(fullPath, content)
+	}
+
+	function writeSharedTemplateProject(root) {
+		writeProjectFile(root, 'app.json', JSON.stringify({ pages: ['pages/one/index', 'pages/two/index'] }))
+		writeProjectFile(root, 'app.js', 'App({})\n')
+		writeProjectFile(root, 'app.wxss', '')
+		writeProjectFile(root, 'project.config.json', JSON.stringify({ appid: 'shared-template-cache-app' }))
+		for (const name of ['one', 'two']) {
+			writeProjectFile(root, `pages/${name}/index.json`, '{}')
+			writeProjectFile(root, `pages/${name}/index.js`, 'Page({ data: {} })\n')
+			writeProjectFile(root, `pages/${name}/index.wxml`, pageWxml)
+			writeProjectFile(root, `pages/${name}/index.wxss`, '')
+		}
+		writeProjectFile(root, 'templates/card.wxml', cardWxml)
+		writeProjectFile(root, 'templates/format.wxs', formatWxs)
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		perfCacheSpies.compileTemplateCalls.length = 0
+		perfCacheSpies.parseSyncCalls.length = 0
+		originalTargetPath = process.env.TARGET_PATH
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'shared-template-cache-'))
+	})
+
+	afterEach(() => {
+		if (originalTargetPath) process.env.TARGET_PATH = originalTargetPath
+		else delete process.env.TARGET_PATH
+		fs.rmSync(tempDir, { recursive: true, force: true })
+	})
+
+	it('普通模式：两页产物与 WXS 注册一致，具名模板只真正编译一次（第二页命中缓存），依赖图两页都记录', async () => {
+		writeSharedTemplateProject(tempDir)
+		const outputDir = path.join(tempDir, 'dist')
+		fs.mkdirSync(outputDir, { recursive: true })
+		process.env.TARGET_PATH = outputDir
+
+		const { getDependencyGraph, getPages, storeInfo } = await import('../src/env.js')
+		storeInfo(tempDir)
+		const { compileML } = await import('../src/core/view-compiler.js')
+		await compileML(getPages().mainPages, null, { completedTasks: 0 })
+
+		const outputOne = fs.readFileSync(path.join(outputDir, 'main/pages_one_index.js'), 'utf8')
+		const outputTwo = fs.readFileSync(path.join(outputDir, 'main/pages_two_index.js'), 'utf8')
+
+		// 两页产物里共享具名模板的 render 代码必须一致，且都正确注册了模板引用的 WXS 模块
+		expect(outputOne).toContain('card-marker')
+		expect(outputTwo).toContain('card-marker')
+		expect(outputOne).toContain('templates_format')
+		expect(outputTwo).toContain('templates_format')
+
+		// 共享具名模板的 compileTemplate 只应该被真正调用一次：第二页命中 templateRenderCache
+		const cardCompileCalls = perfCacheSpies.compileTemplateCalls.filter(filename => filename === 'tpl-card')
+		expect(cardCompileCalls).toHaveLength(1)
+
+		// 两个页面都包含同一表达式；第二次转换必须复用 optionalChainingCache。
+		const sharedExpressionParseCalls = perfCacheSpies.parseSyncCalls.filter(
+			([filename, code]) => filename === 'view-compiler.js' && code === '(shared.expr.value)',
+		)
+		expect(sharedExpressionParseCalls).toHaveLength(1)
+
+		// 依赖图对两页都记录了对共享模板文件的依赖，不因命中缓存而漏记
+		const graph = getDependencyGraph()
+		const affected = graph.getAffectedEntries(path.join(tempDir, 'templates/card.wxml'))
+		expect(affected).toEqual(expect.arrayContaining(['pages/one/index', 'pages/two/index']))
+	})
+
+	it('sourcemap 模式：两页各自的 source map 都正确回指共享模板源码，不因缓存复用而错位或串页', async () => {
+		writeSharedTemplateProject(tempDir)
+		const outputDir = path.join(tempDir, 'out')
+
+		await build(outputDir, tempDir, false, { sourcemap: true })
+
+		const cardSource = '/templates/card.wxml'
+		const expectedSourceLine = cardWxml.split('\n').findIndex(line => line.includes('format.upper')) + 1
+
+		for (const pageName of ['one', 'two']) {
+			const viewPath = path.join(outputDir, `main/pages_${pageName}_index.js`)
+			const mapPath = `${viewPath}.map`
+			expect(fs.existsSync(mapPath)).toBe(true)
+
+			const viewCode = fs.readFileSync(viewPath, 'utf8')
+			const map = JSON.parse(fs.readFileSync(mapPath, 'utf8'))
+			expect(map.sources).toContain(cardSource)
+			expect(map.sourcesContent[map.sources.indexOf(cardSource)]).toBe(cardWxml)
+
+			const lines = viewCode.split('\n')
+			const wxsCallLine = lines.findIndex(line => line.includes('.upper(')) + 1
+			expect(wxsCallLine).toBeGreaterThan(0)
+
+			const consumer = new SourceMapConsumer(map)
+			const position = consumer.originalPositionFor({
+				line: wxsCallLine,
+				column: lines[wxsCallLine - 1].indexOf('.upper('),
+			})
+			// 命中缓存的页面拿到的是另一页编译时生成的 map 片段，拼接进各自产物后
+			// 仍必须回指共享模板自身的源文件与源码行，不能残留另一页的坐标
+			expect(position.source).toBe(cardSource)
+			expect(position.line).toBe(expectedSourceLine)
+		}
+	})
+})

--- a/fe/packages/compiler/src/common/compatibility.js
+++ b/fe/packages/compiler/src/common/compatibility.js
@@ -211,11 +211,12 @@ function warnUnsupportedComponent(tagName, filePath, line) {
 }
 
 function checkTemplateCompatibility(content, filePath, components = {}) {
+	const newlineOffsets = collectNewlineOffsets(content)
 	let parser
 	parser = new Parser(
 		{
 			onopentag(tagName, attrs) {
-				const line = getLineByIndex(content, parser.startIndex)
+				const line = getLineByIndex(newlineOffsets, parser.startIndex)
 				for (const attributeName of Object.keys(attrs)) {
 					const invalidPrefix = getInvalidAttributePrefix(attributeName)
 					if (invalidPrefix) {
@@ -255,18 +256,39 @@ function checkTemplateCompatibility(content, filePath, components = {}) {
 	parser.end()
 }
 
-function getLineByIndex(content, index) {
+function collectNewlineOffsets(content) {
+	const offsets = []
+	for (let i = 0; i < content.length; i++) {
+		if (content.charCodeAt(i) === 10) {
+			offsets.push(i)
+		}
+	}
+	return offsets
+}
+
+// Binary search over precomputed newline offsets: line = count of newlines
+// strictly before `index`, plus 1. `checkTemplateCompatibility` fires this once
+// per opened tag; a per-call linear rescan from offset 0 (the previous
+// implementation) turned a single template's compatibility check into O(n²) —
+// on taro-ui's shared ~112KB base.wxml (reprocessed per page) that dominated
+// total dmcc compile time (~43% of the view-compile worker's CPU time).
+function getLineByIndex(newlineOffsets, index) {
 	if (typeof index !== 'number' || index < 0) {
 		return null
 	}
 
-	let line = 1
-	for (let i = 0; i < index; i++) {
-		if (content.charCodeAt(i) === 10) {
-			line++
+	let lo = 0
+	let hi = newlineOffsets.length
+	while (lo < hi) {
+		const mid = (lo + hi) >>> 1
+		if (newlineOffsets[mid] < index) {
+			lo = mid + 1
+		}
+		else {
+			hi = mid
 		}
 	}
-	return line
+	return lo + 1
 }
 
 function formatLocation(filePath, line) {

--- a/fe/packages/compiler/src/core/view-compiler.js
+++ b/fe/packages/compiler/src/core/view-compiler.js
@@ -116,9 +116,18 @@ function applyCodeReplacements(source, replacements) {
  * @param {string} expression
  * @returns {string} 添加了可选链操作符的表达式字符串
  */
+// addOptionalChaining 是纯函数（输出只由表达式字符串决定），共享模板（如 Taro 的 base.wxml）
+// 被每个页面各 import 一次时，同一批表达式会被重复解析/重写，用字符串 key 缓存结果去重。
+const optionalChainingCache = new Map()
+
 function addOptionalChaining(expression) {
 	if (!expression || typeof expression !== 'string') {
 		return expression
+	}
+
+	const cached = optionalChainingCache.get(expression)
+	if (cached !== undefined) {
+		return cached
 	}
 
 	try {
@@ -157,8 +166,11 @@ function addOptionalChaining(expression) {
 			}
 		})
 
-		return applyCodeReplacements(code, insertions).slice(1, -1)
+		const result = applyCodeReplacements(code, insertions).slice(1, -1)
+		optionalChainingCache.set(expression, result)
+		return result
 	} catch (error) {
+		optionalChainingCache.set(expression, expression)
 		return expression
 	}
 }
@@ -186,6 +198,12 @@ function transformTextInterpolation(text) {
 
 // 页面文件编译内容缓存
 const compileResCache = new Map()
+
+// 共享模板模块（如被多个页面 import 的同一份模板文件）的 render 编译结果缓存。
+// codegen 固定为 mode:'function'（见 getTemplateCompilerOptions），@vue/compiler-core
+// 只在 module 模式下把 scopeId 写进产物，因此 id/scoped 与页面无关、不入缓存 key；
+// scriptModule 决定注入的 require 声明与 _ctx 成员重写，必须入 key。
+const templateRenderCache = new Map()
 
 // wxs 模块注册表，用于记录确定的 wxs 模块
 const wxsModuleRegistry = new Set()
@@ -223,9 +241,11 @@ if (!isMainThread) {
 
 			// Worker 任务完成后清理所有缓存，释放内存
 			compileResCache.clear()
+			templateRenderCache.clear()
 			wxsModuleRegistry.clear()
 			wxsFilePathMap.clear()
 			wxsScannedWorkPath = null
+			optionalChainingCache.clear()
 
 			parentPort.postMessage({
 				success: true,
@@ -236,9 +256,11 @@ if (!isMainThread) {
 		catch (error) {
 			// 错误时也清理缓存
 			compileResCache.clear()
+			templateRenderCache.clear()
 			wxsModuleRegistry.clear()
 			wxsFilePathMap.clear()
 			wxsScannedWorkPath = null
+			optionalChainingCache.clear()
 
 			parentPort.postMessage({
 				success: false,
@@ -403,6 +425,49 @@ function getTemplateCompilerOptions(scopeId) {
 		// component resolution.
 		isCustomElement: tag => !tag.startsWith('dd-'),
 	}
+}
+
+/**
+ * 编译单个模板模块（<template name>）的 render 结果，并跨页面复用。
+ * 被多个页面 import 的同一份模板文件在每个页面里会产出完全相同的
+ * compileTemplate codegen 与 insertWxsToRenderResult 结果，只需计算一次。
+ * moduleId 不入 key：function 模式下 scopeId 不进入产物（见 templateRenderCache 处说明）。
+ */
+function compileTemplateModuleRender(tm, moduleId, scriptModule, scriptRes) {
+	const scriptSig = scriptModule.map(sm => `${sm.path}\u0000${sm.originalName ?? ''}`).join('\u0001')
+	// sourceInfo.content 是 sourceInfo.path 对应文件的原文，在同一个 worker 任务内该文件
+	// 不会被改写（与 compileResCache 直接按 module.path 做键的既有假设一致），path 已经
+	// 唯一决定 content，不必把可能上百 KB 的原文本身也塞进 key（那样会随具名模板数线性放大）。
+	const sourceSig = tm.sourceInfo
+		? `${tm.sourceInfo.path}\u0000${tm.sourceInfo.startLine ?? ''}`
+		: ''
+	const cacheKey = `${tm.path}\u0002${sourceSig}\u0002${scriptSig}\u0002${tm.tpl}`
+	const cached = templateRenderCache.get(cacheKey)
+	if (cached) {
+		// 跳过 insertWxsToRenderResult 时，补上它对 scriptRes 的登记副作用
+		for (const sm of scriptModule) {
+			if (!scriptRes.has(sm.path)) {
+				scriptRes.set(sm.path, sm.code)
+			}
+		}
+		return cached
+	}
+	const compiledTemplate = compileTemplate({
+		source: tm.tpl,
+		filename: tm.path,
+		id: `data-v-${moduleId}`,
+		scoped: true,
+		inMap: enableSourcemap && tm.sourceInfo
+			? createLineSourcemap(tm.tpl, tm.sourceInfo.path, tm.sourceInfo.content, tm.sourceInfo.startLine)
+			: undefined,
+		compilerOptions: getTemplateCompilerOptions(`data-v-${moduleId}`),
+	})
+	const result = {
+		path: tm.path,
+		...insertWxsToRenderResult(compiledTemplate.code, scriptModule, scriptRes, tm.path, compiledTemplate.map),
+	}
+	templateRenderCache.set(cacheKey, result)
+	return result
 }
 
 /**
@@ -580,20 +645,7 @@ function compileModule(module, isComponent, scriptRes, options = {}) {
 
 	const templateResults = []
 	for (const tm of compileInstruction.templateModule) {
-		const compiledTemplate = compileTemplate({
-			source: tm.tpl,
-			filename: tm.path,
-			id: `data-v-${module.id}`,
-			scoped: true,
-			inMap: enableSourcemap && tm.sourceInfo
-				? createLineSourcemap(tm.tpl, tm.sourceInfo.path, tm.sourceInfo.content, tm.sourceInfo.startLine)
-				: undefined,
-			compilerOptions: getTemplateCompilerOptions(`data-v-${module.id}`),
-		})
-		templateResults.push({
-			path: tm.path,
-			...insertWxsToRenderResult(compiledTemplate.code, compileInstruction.scriptModule, scriptRes, tm.path, compiledTemplate.map),
-		})
+		templateResults.push(compileTemplateModuleRender(tm, module.id, compileInstruction.scriptModule, scriptRes))
 	}
 
 	const renderResult = insertWxsToRenderResult(tplCode.code, compileInstruction.scriptModule, scriptRes, module.path, tplCode.map)
@@ -869,20 +921,7 @@ function compileModuleWithAllWxs(module, scriptRes, allScriptModules, sourceMapR
 
 	const templateResults = []
 	for (const tm of mergedInstruction.templateModule) {
-		const compiledTemplate = compileTemplate({
-			source: tm.tpl,
-			filename: tm.path,
-			id: `data-v-${module.id}`,
-			scoped: true,
-			inMap: enableSourcemap && tm.sourceInfo
-				? createLineSourcemap(tm.tpl, tm.sourceInfo.path, tm.sourceInfo.content, tm.sourceInfo.startLine)
-				: undefined,
-			compilerOptions: getTemplateCompilerOptions(`data-v-${module.id}`),
-		})
-		templateResults.push({
-			path: tm.path,
-			...insertWxsToRenderResult(compiledTemplate.code, allScriptModules, scriptRes, tm.path, compiledTemplate.map),
-		})
+		templateResults.push(compileTemplateModuleRender(tm, module.id, allScriptModules, scriptRes))
 	}
 
 	const renderResult = insertWxsToRenderResult(tplCode.code, allScriptModules, scriptRes, module.path, tplCode.map)
@@ -1238,6 +1277,9 @@ function toCompileTemplate(isComponent, path, components, componentPlaceholder, 
 
 function transTagTemplate($, templateModule, path, components, componentPlaceholder, sourceInfo, graphOwnerPath = path) {
 	const templateNodes = $('template[name]')
+	// 同一 sourceInfo.content 会被本循环内每个具名 template 节点各查询一次行号，
+	// 换行位置只需算一次，逐节点二分查找，避免每节点都从头重新扫描全文。
+	const newlineOffsets = sourceInfo ? collectNewlineOffsets(sourceInfo.content) : null
 	templateNodes.each((_, elem) => {
 		const name = $(elem).attr('name')
 		const templateContent = $(elem)
@@ -1256,7 +1298,7 @@ function transTagTemplate($, templateModule, path, components, componentPlacehol
 			sourceInfo: sourceInfo
 				? {
 					...sourceInfo,
-					startLine: getSourceLine(sourceInfo.content, elem.children?.[0]?.startIndex ?? elem.startIndex),
+					startLine: getSourceLine(newlineOffsets, elem.children?.[0]?.startIndex ?? elem.startIndex),
 				}
 				: null,
 		})
@@ -1264,8 +1306,33 @@ function transTagTemplate($, templateModule, path, components, componentPlacehol
 	templateNodes.remove()
 }
 
-function getSourceLine(source, index = 0) {
-	return source.slice(0, Math.max(0, index)).split('\n').length
+function collectNewlineOffsets(content) {
+	const offsets = []
+	for (let i = 0; i < content.length; i++) {
+		if (content.charCodeAt(i) === 10) {
+			offsets.push(i)
+		}
+	}
+	return offsets
+}
+
+function getSourceLine(newlineOffsets, index = 0) {
+	if (!newlineOffsets) {
+		return 1
+	}
+	const target = Math.max(0, index)
+	let lo = 0
+	let hi = newlineOffsets.length
+	while (lo < hi) {
+		const mid = (lo + hi) >>> 1
+		if (newlineOffsets[mid] < target) {
+			lo = mid + 1
+		}
+		else {
+			hi = mid
+		}
+	}
+	return lo + 1
 }
 
 function transAsses($, imageNodes, path, graphOwnerPath = path) {


### PR DESCRIPTION
## 背景

Taro 项目通常会让多个页面引用同一份 `base.wxml`。在包含约 200 个具名模板、63 个页面的参考项目中，view compiler 会重复解析相同内容，导致编译较慢。

## 优化

- 预先记录换行位置，减少重复扫描。
- 缓存相同表达式的可选链转换结果。
- 在多个页面之间复用共享具名模板的编译结果。

缓存会在 worker 任务结束后清理，兼容性检查、依赖收集和静态资源处理仍会按页面执行。

## 性能

在 **Mac mini（M4）** 上测试 taro-ui 参考项目（3 次独立进程运行取中位数）：

- 当前 `main`：40.96 秒
- 本 PR：5.16 秒

约 8 倍提速。63 个页面生成的 118 个产物文件与优化前逐文件一致，兼容性警告也保持一致。

## 验证

- `pnpm --filter compiler exec vitest run`：341 tests passed
- `pnpm lint`
- `pnpm --filter compiler build`
- GitHub Frontend Lint / Frontend Tests