### PR TITLE
fix(service): isolate Page data by instance

### DIFF
--- a/fe/packages/service/__tests__/page-data-isolation.spec.js
+++ b/fe/packages/service/__tests__/page-data-isolation.spec.js
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { PageModule } from '../src/instance/page/page-module'
+import { Page } from '../src/instance/page/page'
+
+describe('Page data isolation', () => {
+	function createPageModule() {
+		return new PageModule({
+			data: {
+				count: 0,
+				profile: { nick: 'anonymous' },
+			},
+		}, {
+			path: 'pages/demo/index',
+			usingComponents: {},
+		})
+	}
+
+	function createPage(pageModule, bridgeId) {
+		const page = new Page(pageModule, {
+			bridgeId,
+			moduleId: `${bridgeId}-module`,
+			path: 'pages/demo/index',
+			query: {},
+		})
+		page.init()
+		return page
+	}
+
+	it('starts a new instance from the declared defaults', () => {
+		const pageModule = createPageModule()
+		const first = createPage(pageModule, 'bridge-first')
+
+		first.setData({ count: 1 })
+		first.setData({ 'profile.nick': 'first' })
+
+		const second = createPage(pageModule, 'bridge-second')
+		expect(second.data).toEqual({
+			count: 0,
+			profile: { nick: 'anonymous' },
+		})
+	})
+
+	it('does not modify the module data declaration', () => {
+		const pageModule = createPageModule()
+		const page = createPage(pageModule, 'bridge-only')
+
+		page.setData({ count: 42 })
+		page.setData({ 'profile.nick': 'written' })
+
+		expect(pageModule.moduleInfo.data).toEqual({
+			count: 0,
+			profile: { nick: 'anonymous' },
+		})
+		expect(pageModule.noReferenceData).toEqual({
+			count: 0,
+			profile: { nick: 'anonymous' },
+		})
+	})
+
+	it('keeps live instances independent', () => {
+		const pageModule = createPageModule()
+		const first = createPage(pageModule, 'bridge-a')
+		const second = createPage(pageModule, 'bridge-b')
+
+		first.setData({ count: 7 })
+		second.setData({ count: 9 })
+
+		expect(first.data.count).toBe(7)
+		expect(second.data.count).toBe(9)
+		expect(first.data).not.toBe(second.data)
+	})
+})

--- a/fe/packages/service/src/instance/page/page.js
+++ b/fe/packages/service/src/instance/page/page.js
@@ -163,6 +163,10 @@ export class Page {
 	// 开发者自定义函数
 	#initMembers() {
 		for (const attr in this.__info__) {
+			// The constructor already creates an instance-owned copy of data.
+			if (attr === 'data') {
+				continue
+			}
 			const member = this.__info__[attr]
 			if (isFunction(member)) {
 				this[attr] = member.bind(this)


### PR DESCRIPTION
`Page` 构造函数会复制声明的默认 `data`，但随后通用成员初始化又把模块级 `data` 赋回实例。`setData` 因此会修改共享声明，导致同时存活的页面实例互相影响，重新创建页面也可能继承上一次的值。

本 PR 让 `data` 只由构造函数初始化，其他自定义成员仍沿用原有逻辑。回归测试覆盖重新创建恢复默认值、模块声明不被修改，以及两个存活实例互不影响。

验证：同一组 3 项测试在 `origin/main` 上全部失败，应用修复后全部通过；service 全量 728 项测试和 FE lint 通过。
