### PR TITLE
fix(fe): fail app generation when zip creation fails

### DIFF
--- a/fe/package.json
+++ b/fe/package.json
@@ -19,7 +19,8 @@
     "preview:container": "pnpm --dir ./packages/container preview",
     "generate:sdk": "node ./scripts/generate-sdk.js",
     "generate:app": "node ./scripts/generate-app.js",
-    "test": "pnpm --filter compiler --filter common --filter components --filter service --filter render --filter container --filter fe-container-sdk test",
+    "test": "pnpm --filter compiler --filter common --filter components --filter service --filter render --filter container --filter fe-container-sdk test && pnpm test:scripts",
+    "test:scripts": "node --test scripts/generate-app.test.js",
     "coverage": "pnpm --filter compiler --filter common --filter components --filter service --filter render --filter container --filter fe-container-sdk coverage",
     "lint": "oxlint",
     "lint:fix": "oxlint --fix"

--- a/fe/scripts/generate-app.js
+++ b/fe/scripts/generate-app.js
@@ -16,10 +16,10 @@ async function createZip(sourceDir, outputPath) {
 	const { ZipArchive } = await import('archiver')
 
 	return new Promise((resolve, reject) => {
-		const output = fs.createWriteStream(outputPath)
 		const archive = new ZipArchive({
 			zlib: { level: 9 }, // Maximum compression
 		})
+		const output = fs.createWriteStream(outputPath)
 
 		output.on('close', () => {
 			console.log(`Successfully created ${outputPath} (${archive.pointer()} bytes)`)
@@ -42,6 +42,8 @@ async function createZip(sourceDir, outputPath) {
 
 // Main async function
 async function main() {
+	const failedAppIds = []
+
 	// Check if the shared/jsapp directory exists
 	if (!fs.existsSync(sharedJsappPath)) {
 		console.error(`Error: Directory ${sharedJsappPath} does not exist.`)
@@ -135,7 +137,12 @@ async function main() {
 		}
 		catch (error) {
 			console.error(`Error creating zip for ${appId}:`, error)
+			failedAppIds.push(appId)
 		}
+	}
+
+	if (failedAppIds.length > 0) {
+		throw new Error(`Failed to create zip for: ${failedAppIds.join(', ')}`)
 	}
 
 	console.log('App generation completed successfully!')

--- a/fe/scripts/generate-app.js
+++ b/fe/scripts/generate-app.js
@@ -20,19 +20,22 @@ async function createZip(sourceDir, outputPath) {
 			zlib: { level: 9 }, // Maximum compression
 		})
 		const output = fs.createWriteStream(outputPath)
+		let failed = false
+		const handleError = (error) => {
+			failed = true
+			reject(error)
+		}
 
 		output.on('close', () => {
+			if (failed) {
+				return
+			}
 			console.log(`Successfully created ${outputPath} (${archive.pointer()} bytes)`)
 			resolve()
 		})
 
-		archive.on('error', (err) => {
-			reject(err)
-		})
-
-		output.on('error', (err) => {
-			reject(err)
-		})
+		archive.on('error', handleError)
+		output.on('error', handleError)
 
 		archive.pipe(output)
 		archive.directory(sourceDir, false)

--- a/fe/scripts/generate-app.test.js
+++ b/fe/scripts/generate-app.test.js
@@ -26,5 +26,6 @@ test('generate-app fails when an app zip cannot be created', async (t) => {
 
 	assert.notEqual(result.status, 0)
 	assert.match(result.stderr, /Failed to create zip for: wx-test/)
+	assert.doesNotMatch(result.stdout, /Successfully created .*wx-test\.zip/)
 	assert.doesNotMatch(result.stdout, /App generation completed successfully/)
 })

--- a/fe/scripts/generate-app.test.js
+++ b/fe/scripts/generate-app.test.js
@@ -1,0 +1,30 @@
+const assert = require('node:assert/strict')
+const { mkdtemp, mkdir, rm, symlink, writeFile } = require('node:fs/promises')
+const os = require('node:os')
+const path = require('node:path')
+const { spawnSync } = require('node:child_process')
+const test = require('node:test')
+
+const sourceFePath = path.resolve(__dirname, '..')
+
+test('generate-app fails when an app zip cannot be created', async (t) => {
+	const root = await mkdtemp(path.join(os.tmpdir(), 'dimina-generate-app-'))
+	t.after(() => rm(root, { recursive: true, force: true }))
+
+	const fixtureFePath = path.join(root, 'fe')
+	const appPath = path.join(fixtureFePath, 'packages/container/public/wx-test/main')
+	const sharedAppPath = path.join(root, 'shared/jsapp/wx-test')
+	await mkdir(appPath, { recursive: true })
+	await mkdir(sharedAppPath, { recursive: true })
+	await writeFile(path.join(appPath, 'app-config.json'), JSON.stringify({ app: { pages: ['index'] }, projectName: 'Test' }))
+	await mkdir(path.join(sharedAppPath, 'wx-test.zip'))
+	await mkdir(path.join(fixtureFePath, 'scripts'), { recursive: true })
+	await symlink(path.join(sourceFePath, 'node_modules'), path.join(fixtureFePath, 'node_modules'))
+	await writeFile(path.join(fixtureFePath, 'scripts/generate-app.js'), await require('node:fs/promises').readFile(path.join(__dirname, 'generate-app.js')))
+
+	const result = spawnSync(process.execPath, [path.join(fixtureFePath, 'scripts/generate-app.js')], { encoding: 'utf8' })
+
+	assert.notEqual(result.status, 0)
+	assert.match(result.stderr, /Failed to create zip for: wx-test/)
+	assert.doesNotMatch(result.stdout, /App generation completed successfully/)
+})


### PR DESCRIPTION
`generate-app.js` 逐个生成小程序包。此前单个 zip 创建失败时，脚本只打印错误，处理完其他小程序后仍输出成功并以退出码 0 结束。下游任务因此可能把缺失或不完整的包当作有效产物。

本 PR 记录生成失败的小程序，继续处理其余任务，并在结束时返回非零退出码。同时先创建压缩器再打开目标文件，避免压缩器初始化失败时提前清空已有文件。回归测试构造无法写入的 zip 目标，验证脚本不会再报告成功。
