### PR TITLE
fix(fe): refresh host environment after shell geometry changes

### DIFF
--- a/fe/packages/container-sdk/README.md
+++ b/fe/packages/container-sdk/README.md
@@ -70,6 +70,7 @@ resourceBaseUrl/
 |---|---|
 | `mount` | 必填，容器根元素 |
 | `shell.getStatusBarRect` | 宿主提供状态栏几何（`{top,left,width,height,...}`），用于自定义导航栏 / 胶囊按钮布局对齐 |
+| `shell.subscribeStatusBarRectChange` | 可选的状态栏几何变化订阅。宿主切换机型、方向或安全区后调用传入的 listener，并返回取消订阅函数；SDK 会把最新窗口和状态栏信息同步到小程序逻辑线程 |
 | `shell.updateStatusBarColor` | 状态栏前景色（黑/白）变化通知，供宿主壳联动切换深浅色 |
 | `resourceBaseUrl` | 小程序资源请求基路径，缺省 `/`。经真实 `URL` 解析归一化为绝对 URL（相对路径按 `window.location.origin` 解析），畸形输入同步抛错。宿主部署在非根路径时必须显式传入 |
 | `pageFrameUrl` | 渲染层 iframe 的 URL，缺省基于归一化后的 `resourceBaseUrl` 解析出 `pageFrame.html`；同样经 `URL` 解析，畸形输入同步抛错 |
@@ -109,6 +110,7 @@ const container = createContainer({
 	mount: document.getElementById('root'),
 	shell: {
 		getStatusBarRect: () => hostShell.getStatusBarRect(),
+		subscribeStatusBarRectChange: listener => hostShell.subscribeStatusBarRectChange(listener),
 		updateStatusBarColor: color => hostShell.setStatusBarColor(color),
 	},
 	resourceBaseUrl: '/static/miniapp/',

--- a/fe/packages/container-sdk/__tests__/shell-status-bar.spec.ts
+++ b/fe/packages/container-sdk/__tests__/shell-status-bar.spec.ts
@@ -37,6 +37,72 @@ describe('shell status bar adapter', () => {
 		expect(systemInfo.statusBarHeight).toBe(44)
 	}, 10000)
 
+	it('refreshes the service host environment when the DeviceKit viewport changes', async () => {
+		let statusBarRect = { top: 0, left: 0, width: 375, height: 44, right: 375, bottom: 44 }
+		let viewportRect = { top: 0, left: 0, width: 375, height: 812, right: 375, bottom: 812 }
+		const container = createContainer({ mount, shell: { getStatusBarRect: () => statusBarRect } })
+		const miniApp = await container.openApp({ appId: 'wx-shell-resize', path: 'pages/index/index' })
+		const viewport = miniApp.parent!.el.querySelector<HTMLElement>('.dimina-native-webview__root')!
+		vi.spyOn(viewport, 'getBoundingClientRect').mockImplementation(() => viewportRect as DOMRect)
+		const postMessage = vi.spyOn(miniApp.jscore, 'postMessage')
+
+		statusBarRect = { top: 0, left: 0, width: 430, height: 54, right: 430, bottom: 54 }
+		viewportRect = { top: 0, left: 0, width: 430, height: 932, right: 430, bottom: 932 }
+		miniApp._bindHostEnvChanges()
+		globalThis.dispatchEvent(new Event('resize'))
+
+		expect(postMessage).toHaveBeenCalledWith({
+			type: 'hostEnvUpdate',
+			body: {
+				menuRect: expect.objectContaining({ top: 58 }),
+				systemInfo: expect.objectContaining({
+					windowWidth: 430,
+					windowHeight: 932,
+					statusBarHeight: 54,
+				}),
+			},
+		})
+		const hostEnvUpdateCount = postMessage.mock.calls.filter(([message]) => message.type === 'hostEnvUpdate').length
+		expect(hostEnvUpdateCount).toBe(1)
+
+		miniApp.destroy()
+		globalThis.dispatchEvent(new Event('resize'))
+		expect(postMessage.mock.calls.filter(([message]) => message.type === 'hostEnvUpdate')).toHaveLength(hostEnvUpdateCount)
+	}, 10000)
+
+	it('refreshes the service host environment when only the shell status bar geometry changes', async () => {
+		let statusBarRect = { top: 0, left: 0, width: 375, height: 44, right: 375, bottom: 44 }
+		let notifyStatusBarRectChange: (() => void) | undefined
+		const unsubscribe = vi.fn()
+		const shell = {
+			getStatusBarRect: () => statusBarRect,
+			subscribeStatusBarRectChange(listener: () => void) {
+				notifyStatusBarRectChange = listener
+				return unsubscribe
+			},
+		}
+		const container = createContainer({ mount, shell })
+		const miniApp = await container.openApp({ appId: 'wx-shell-status-bar-resize', path: 'pages/index/index' })
+		const postMessage = vi.spyOn(miniApp.jscore, 'postMessage')
+
+		statusBarRect = { top: 0, left: 0, width: 375, height: 50, right: 375, bottom: 50 }
+		notifyStatusBarRectChange?.()
+
+		expect(postMessage).toHaveBeenCalledWith({
+			type: 'hostEnvUpdate',
+			body: {
+				menuRect: expect.objectContaining({ top: 54 }),
+				systemInfo: expect.objectContaining({
+					windowWidth: 375,
+					statusBarHeight: 50,
+				}),
+			},
+		})
+
+		miniApp.destroy()
+		expect(unsubscribe).toHaveBeenCalledTimes(1)
+	}, 10000)
+
 	it('does not throw during app boot when shell.updateStatusBarColor is not provided', async () => {
 		const container = createContainer({ mount })
 

--- a/fe/packages/container-sdk/src/config.ts
+++ b/fe/packages/container-sdk/src/config.ts
@@ -22,6 +22,10 @@ function defaultGetStatusBarRect(): StatusBarRect {
 
 function noop() {}
 
+function noopSubscribe(): () => void {
+	return noop
+}
+
 /**
  * Normalize the host-selected virtual file scheme once per container instance.
  * Keeping this value on Application avoids one container changing another through
@@ -49,6 +53,9 @@ export function resolveShell(shell: ShellAdapter = {}): ResolvedShell {
 	return {
 		getStatusBarRect: shell.getStatusBarRect ? shell.getStatusBarRect.bind(shell) : defaultGetStatusBarRect,
 		updateStatusBarColor: shell.updateStatusBarColor ? shell.updateStatusBarColor.bind(shell) : noop,
+		subscribeStatusBarRectChange: shell.subscribeStatusBarRectChange
+			? shell.subscribeStatusBarRectChange.bind(shell)
+			: noopSubscribe,
 	}
 }
 

--- a/fe/packages/container-sdk/src/pages/miniApp/miniApp.ts
+++ b/fe/packages/container-sdk/src/pages/miniApp/miniApp.ts
@@ -286,6 +286,8 @@ export class MiniApp {
 	_wakeLockVisibilityHandler: (() => void) | null
 	_mediaPreviewEl: HTMLElement | null
 	_tempObjectUrls: Set<string>
+	_hostEnvChangeHandler: (() => void) | null
+	_hostEnvChangeUnsubscribe: (() => void) | null
 	/** app.tabBar 配置 */
 	tabBarConfig: TabBarConfig | null
 	/** 与 list 等长，pagePath 数组（已规范化、无前导 /） */
@@ -354,6 +356,8 @@ export class MiniApp {
 		this._wakeLockVisibilityHandler = null
 		this._mediaPreviewEl = null
 		this._tempObjectUrls = new Set()
+		this._hostEnvChangeHandler = null
+		this._hostEnvChangeUnsubscribe = null
 		this.tabBarConfig = null
 		this.tabBarPaths = []
 		this.tabBarEl = null
@@ -902,6 +906,7 @@ export class MiniApp {
 				// 资源加载完成不代表首屏已经挂载；页面与小游戏统一等本轮 domReady。
 				await entryPageBridge.startAndWait(startOptions)
 			}
+			this._bindHostEnvChanges()
 
 			this.safeSyncUrl()
 
@@ -2385,6 +2390,12 @@ export class MiniApp {
 		this._mediaPreviewEl = null
 		for (const url of this._tempObjectUrls) URL.revokeObjectURL(url)
 		this._tempObjectUrls.clear()
+		if (this._hostEnvChangeHandler) {
+			globalThis.removeEventListener?.('resize', this._hostEnvChangeHandler)
+			this._hostEnvChangeHandler = null
+		}
+		this._hostEnvChangeUnsubscribe?.()
+		this._hostEnvChangeUnsubscribe = null
 		if (this._themeMediaQuery?.removeEventListener) {
 			this._themeMediaQuery.removeEventListener('change', this._themeChangeHandler!)
 		}
@@ -2566,6 +2577,24 @@ export class MiniApp {
 			errMsg: 'getSystemInfo:ok',
 		})
 		onComplete?.()
+	}
+
+	_bindHostEnvChanges(): void {
+		if (this._hostEnvChangeHandler || !globalThis.addEventListener) {
+			return
+		}
+
+		this._hostEnvChangeHandler = () => {
+			if (this._destroyed) {
+				return
+			}
+			this.jscore.postMessage({
+				type: 'hostEnvUpdate',
+				body: this.getHostEnvSnapshot(),
+			})
+		}
+		globalThis.addEventListener('resize', this._hostEnvChangeHandler)
+		this._hostEnvChangeUnsubscribe = this.parent?.shell?.subscribeStatusBarRectChange?.(this._hostEnvChangeHandler) ?? null
 	}
 
 	onWindowResize(opts: { success?: CallbackId } = {}): void {

--- a/fe/packages/container-sdk/src/types.ts
+++ b/fe/packages/container-sdk/src/types.ts
@@ -21,12 +21,14 @@ export interface StatusBarRect {
 export interface ShellAdapter {
 	getStatusBarRect?: () => StatusBarRect
 	updateStatusBarColor?: (color: string) => void
+	subscribeStatusBarRectChange?: (listener: () => void) => (() => void) | void
 }
 
-/** resolveShell() 归一化后的形状：两个方法都保证存在（缺省安全实现）。 */
+/** resolveShell() 归一化后的形状：所有方法都保证存在（缺省安全实现）。 */
 export interface ResolvedShell {
 	getStatusBarRect: () => StatusBarRect
 	updateStatusBarColor: (color: string) => void
+	subscribeStatusBarRectChange: (listener: () => void) => (() => void) | void
 }
 
 /** 小程序元信息，由宿主 getAppInfo(appId) 提供。 */
@@ -120,7 +122,7 @@ export type ExtModuleHandler = (payload: {
 export interface CreateContainerOptions {
 	/** 容器根元素，SDK 把应用视图树挂到这里 */
 	mount: HTMLElement
-	/** 宿主 shell 适配器：{ getStatusBarRect, updateStatusBarColor } */
+	/** 宿主 shell 适配器：状态栏几何、变化订阅与前景色联动 */
 	shell?: ShellAdapter
 	/** 小程序资源基路径 */
 	resourceBaseUrl?: string


### PR DESCRIPTION
切换宿主机型后，渲染区域会使用新的尺寸和状态栏高度，但逻辑线程仍保留首次加载时的 `hostEnv`。这会让 `getSystemInfoSync()`、`getWindowInfo()` 和胶囊位置继续返回旧值；屏幕尺寸相同、只有状态栏高度不同的机型也不会触发浏览器 `resize`。

这个改动为 `ShellAdapter` 增加可选的 `subscribeStatusBarRectChange`，并在窗口或宿主状态栏几何变化时向逻辑线程发送完整的最新环境信息。小程序销毁时会同时移除窗口监听和宿主订阅。

验证：

- `pnpm -C fe/packages/container-sdk test`：309 tests passed
- `pnpm -C fe/packages/container-sdk typecheck`
- `pnpm -C fe/packages/container-sdk build`

影响范围仅限 Web `container-sdk`；Android、iOS 和 HarmonyOS 不使用这个宿主接口。

当前保持 Draft：上游 `main` 的前端 lint 已在 `packages/container/__tests__/map-location.spec.js`、`packages/components/src/component/map/providers/amap.js` 和 `packages/components/__tests__/map-provider.spec.js` 存在 3 个错误。本 PR 没有改动这些文件；前端测试已通过。
